### PR TITLE
407 - Integrate SCassandra into test framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp-driver"]
 	path = cpp-driver
 	url = https://github.com/datastax/cpp-driver.git
+[submodule "tests/src/integration/scassandra/server"]
+	path = tests/src/integration/scassandra/server
+	url = https://github.com/tolbertam/scassandra-server.git

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 
 # Build the base include paths for the tests
 set(TESTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(TESTS_SCASSANDRA_SOURCE_DIR "${TESTS_SOURCE_DIR}/integration/scassandra")
+set(TESTS_SCASSANDRA_SERVER_SOURCE_DIR "${TESTS_SCASSANDRA_SOURCE_DIR}/server")
 set(VENDOR_DIR "${TESTS_SOURCE_DIR}/vendor")
 include_directories(${VENDOR_DIR})
 
@@ -70,9 +72,63 @@ else()
 endif()
 
 #------------------------------
+# RapidJSON
+#------------------------------
+file(GLOB RAPIDJSON_HEADER_FILES ${RAPID_JSON_INCLUDE_DIR}/rapidjson/*.h)
+file(GLOB RAPIDJSON_ERROR_HEADER_FILES ${RAPID_JSON_INCLUDE_DIR}/rapidjson/error/*.h)
+file(GLOB RAPIDJSON_INTERNAL_HEADER_FILES ${RAPID_JSON_INCLUDE_DIR}/rapidjson/internal/*.h)
+file(GLOB RAPIDJSON_MSIINTTYPES_HEADER_FILES ${RAPID_JSON_INCLUDE_DIR}/rapidjson/msiinttypes/*.h)
+source_group("Header Files\\rapidjson" FILES ${RAPIDJSON_HEADER_FILES})
+source_group("Header Files\\rapidjson\\error" FILES ${RAPIDJSON_ERROR_HEADER_FILES})
+source_group("Header Files\\rapidjson\\internal" FILES ${RAPIDJSON_INTERNAL_HEADER_FILES})
+source_group("Header Files\\rapidjson\\msiinttypes" FILES ${RAPIDJSON_MSIINTTYPES_HEADER_FILES})
+include_directories(${RAPID_JSON_INCLUDE_DIR})
+
+#------------------------------
 # Integration test executable
 #------------------------------
 if(DSE_BUILD_INTEGRATION_TESTS)
+  # Determine if SCassandra server can be built (Java is available)
+  find_package(Java COMPONENTS Development)
+  if(Java_Development_FOUND)
+    # Determine if the submodule should be initialized
+    set(SCASSANDRA_SERVER_BUILD_SCRIPT "./gradlew")
+    if(WIN32)
+      set(SCASSANDRA_SERVER_BUILD_SCRIPT "gradlew.bat")
+    endif()
+    if(NOT EXISTS "${TESTS_SCASSANDRA_SERVER_SOURCE_DIR}/${SCASSANDRA_SERVER_BUILD_SCRIPT}")
+      find_package(Git REQUIRED)
+      execute_process(COMMAND git submodule update --init --recursive
+        WORKING_DIRECTORY ${TESTS_SCASSANDRA_SERVER_SOURCE_DIR}
+        OUTPUT_QUIET)
+    endif()
+
+    # Build SCassandra server
+    file(GLOB SCASSANDRA_SERVER_STANDALONE_JAR
+      ${TESTS_SCASSANDRA_SERVER_SOURCE_DIR}/server/build/libs/scassandra-server_*-standalone.jar)
+    if(NOT EXISTS ${SCASSANDRA_SERVER_STANDALONE_JAR})
+      message(STATUS "Building standalone SCassandra server")
+      execute_process(COMMAND ${SCASSANDRA_SERVER_BUILD_SCRIPT} server:fatJar
+        WORKING_DIRECTORY ${TESTS_SCASSANDRA_SERVER_SOURCE_DIR}
+        OUTPUT_QUIET)
+      file(GLOB SCASSANDRA_SERVER_STANDALONE_JAR
+        ${TESTS_SCASSANDRA_SERVER_SOURCE_DIR}/server/build/libs/scassandra-server_*-standalone.jar)
+    endif()
+  endif()
+
+  # Determine if the SCassandra server will be available for the tests
+  if(EXISTS ${SCASSANDRA_SERVER_STANDALONE_JAR})
+    # Copy the standalone SCassandra server JAR file to output directory
+    configure_file(${SCASSANDRA_SERVER_STANDALONE_JAR} ${CMAKE_BINARY_DIR} COPYONLY)
+    if(WIN32)
+      # Copy SCassandra server to additional locations for use with IDE
+      configure_file(${SCASSANDRA_SERVER_STANDALONE_JAR} ${CMAKE_BINARY_DIR}/tests COPYONLY)
+      configure_file(${SCASSANDRA_SERVER_STANDALONE_JAR} ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE} COPYONLY)
+    endif()
+  else()
+    message(WARNING "SCassandra Not Found: SCassandra support will be disabled")
+  endif()
+
   # Add CCM bridge functionality from the Cassandra driver
   set(CCM_BRIDGE_DIR ${CASS_SOURCE_DIR}/test/ccm_bridge)
   set(CCM_BRIDGE_SOURCE_DIR ${CCM_BRIDGE_DIR}/src)
@@ -127,12 +183,29 @@ if(DSE_BUILD_INTEGRATION_TESTS)
   source_group("Source Files" FILES ${INTEGRATION_TESTS_SOURCE_FILES})
   source_group("Source Files\\objects" FILES ${INTEGRATION_TESTS_OBJECTS_SOURCE_FILES})
   source_group("Source Files\\tests" FILES ${INTEGRATION_TESTS_TESTS_SOURCE_FILES})
+  if (EXISTS ${SCASSANDRA_SERVER_STANDALONE_JAR})
+    # Configure the integration tests to use SCassandra
+    add_definitions(-DDSE_USE_STANDALONE_SCASSANDRA_SERVER)
+    get_filename_component(SCASSANDRA_SERVER_STANDALONE_JAR_BASENAME
+      ${SCASSANDRA_SERVER_STANDALONE_JAR} NAME)
+    add_definitions(-DSCASSANDRA_SERVER_JAR="${SCASSANDRA_SERVER_STANDALONE_JAR_BASENAME}")
+    file(GLOB INTEGRATION_TESTS_SCASSANDRA_INCLUDE_FILES ${TESTS_SCASSANDRA_SOURCE_DIR}/*.hpp)
+    file(GLOB INTEGRATION_TESTS_SCASSANDRA_SOURCE_FILES ${TESTS_SCASSANDRA_SOURCE_DIR}/*.cpp)
+    file(GLOB INTEGRATION_TESTS_SCASSANDRA_TESTS_SOURCE_FILES ${INTEGRATION_TESTS_SOURCE_DIR}/tests/scassandra/*.cpp)
+    source_group("Header Files\\scassandra" FILES ${INTEGRATION_TESTS_SCASSANDRA_INCLUDE_FILES})
+    source_group("Source Files\\scassandra" FILES ${INTEGRATION_TESTS_SCASSANDRA_SOURCE_FILES})
+    source_group("Source Files\\tests\\scassandra" FILES ${INTEGRATION_TESTS_SCASSANDRA_TESTS_SOURCE_FILES})
+    include_directories(${TESTS_SCASSANDRA_SOURCE_DIR})
+  endif()
   add_executable(${INTEGRATION_TESTS_NAME} ${INTEGRATION_TESTS_SOURCE_FILES}
     ${INTEGRATION_TESTS_OBJECTS_SOURCE_FILES}
+    ${INTEGRATION_TESTS_SCASSANDRA_SOURCE_FILES}
     ${INTEGRATION_TESTS_TESTS_SOURCE_FILES}
+    ${INTEGRATION_TESTS_SCASSANDRA_TESTS_SOURCE_FILES}
     ${CPP_DRIVER_SOURCE_FILES}
     ${INTEGRATION_TESTS_INCLUDE_FILES}
     ${INTEGRATION_TESTS_OBJECTS_INCLUDE_FILES}
+    ${INTEGRATION_TESTS_SCASSANDRA_INCLUDE_FILES}
     ${INTEGRATION_TESTS_VALUES_INCLUDE_FILES}
     ${CCM_INCLUDE_FILES}
     ${CASSANDRA_API_HEADER_FILES}
@@ -146,7 +219,8 @@ if(DSE_BUILD_INTEGRATION_TESTS)
     ${GOOGLE_TEST_SOURCE_FILES}
     ${LIBUV_INCLUDE_FILES}
     ${LIBSSH2_INCLUDE_FILES}
-    ${OPENSSL_INCLUDE_FILES})
+    ${OPENSSL_INCLUDE_FILES}
+    ${RAPIDJSON_HEADER_FILES})
   if(CMAKE_VERSION VERSION_LESS "2.8.11")
     include_directories(${INTEGRATION_TESTS_SOURCE_DIR})
   else()
@@ -161,8 +235,8 @@ if(DSE_BUILD_INTEGRATION_TESTS)
   set_property(TARGET ${INTEGRATION_TESTS_NAME} PROPERTY FOLDER "Tests")
   set_property(TARGET ${INTEGRATION_TESTS_NAME} APPEND PROPERTY COMPILE_FLAGS ${TEST_CXX_FLAGS})
 
-  # Copy data file to output directory
-configure_file(embedded-ads.jar ${CMAKE_BINARY_DIR} COPYONLY)
+  # Copy the ADS JAR file to output directory
+  configure_file(embedded-ads.jar ${CMAKE_BINARY_DIR} COPYONLY)
 endif()
 
 #------------------------------

--- a/tests/src/integration/driver_utils.cpp
+++ b/tests/src/integration/driver_utils.cpp
@@ -1,0 +1,49 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#include "driver_utils.hpp"
+
+#include "address.hpp"
+#include "future.hpp"
+#include "request_handler.hpp"
+#include "statement.hpp"
+
+const std::vector<std::string> test::driver::internals::Utils::attempted_hosts(
+  CassFuture* future) {
+  std::vector<std::string> attempted_hosts;
+  if (future) {
+  cass::Future* cass_future = static_cast<cass::Future*>(future);
+  if (cass_future->type() == cass::CASS_FUTURE_TYPE_RESPONSE) {
+    cass::ResponseFuture* response = static_cast<cass::ResponseFuture*>(cass_future);
+    cass::AddressVec attempted_addresses = response->attempted_addresses();
+    for (cass::AddressVec::iterator iterator = attempted_addresses.begin();
+      iterator != attempted_addresses.end(); ++iterator) {
+      attempted_hosts.push_back(iterator->to_string());
+    }
+    std::sort(attempted_hosts.begin(), attempted_hosts.end());
+  }
+  }
+  return attempted_hosts;
+}
+
+const std::string test::driver::internals::Utils::host(CassFuture* future) {
+  if (future) {
+    cass::Future* cass_future = static_cast<cass::Future*>(future);
+    if (cass_future->type() == cass::CASS_FUTURE_TYPE_RESPONSE) {
+      return static_cast<cass::ResponseFuture*>(cass_future)->address().to_string();
+    }
+  }
+  return "";
+}
+
+void test::driver::internals::Utils::set_record_attempted_hosts(
+  CassStatement* statement, bool enable) {
+  if (statement) {
+    static_cast<cass::Statement*>(statement)
+      ->set_record_attempted_addresses(enable);
+  }
+}

--- a/tests/src/integration/driver_utils.hpp
+++ b/tests/src/integration/driver_utils.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __TEST_DRIVER_UTILS_HPP__
+#define __TEST_DRIVER_UTILS_HPP__
+
+#include "cassandra.h"
+
+#include <string>
+#include <vector>
+
+namespace test {
+namespace driver {
+namespace internals {
+
+class Utils {
+public:
+  /**
+   * Get the attempted hosts/addresses of the future (sorted)
+   *
+   * @param future Future to retrieve hosts/addresses from
+   * @return Attempted hosts/Addresses (sorted)
+   */
+  static const std::vector<std::string> attempted_hosts(CassFuture* future);
+
+  /**
+   * Get the host/address of the future
+   *
+   * @param future Future to retrieve hosts/addresses from
+   * @return Host/Address
+   */
+  static const std::string host(CassFuture* future);
+
+  /**
+   * Enable/Disable the recording of hosts attempted during the execution of
+   * a statement
+   *
+   * @param statement Statement to enable/disable attempted host recording
+   * @param enable True if attempted host should be recorded; false otherwise
+   */
+  static void set_record_attempted_hosts(CassStatement* statement, bool enable);
+
+};
+
+} // namespace internals
+} // namespace driver
+} // namespace test
+
+#endif // __TEST_DRIVER_UTILS_HPP__

--- a/tests/src/integration/dse_integration.hpp
+++ b/tests/src/integration/dse_integration.hpp
@@ -15,6 +15,13 @@
 #include "dse_pretty_print.hpp"
 #include "dse_values.hpp"
 
+// Macros to use for grouping DSE integration tests together
+#define DSE_TEST_NAME(test_name) Integration##_##DSE##_##test_name
+#define DSE_INTEGRATION_TEST_F(test_case, test_name) \
+  INTEGRATION_TEST_F(DSE, test_case, test_name)
+#define DSE_INTEGRATION_TYPED_TEST_P(test_case, test_name) \
+  INTEGRATION_TYPED_TEST_P(DSE, test_case, test_name)
+
 /**
  * Extended class to provide common integration test functionality for DSE
  * tests

--- a/tests/src/integration/integration.cpp
+++ b/tests/src/integration/integration.cpp
@@ -151,7 +151,8 @@ void Integration::TearDown() {
   std::stringstream use_keyspace_query;
   use_keyspace_query << "DROP KEYSPACE " << keyspace_name_;
   try {
-    session_.execute(use_keyspace_query.str(), CASS_CONSISTENCY_ANY, false);
+    session_.execute(use_keyspace_query.str(), CASS_CONSISTENCY_ANY, false,
+      false);
   } catch (...) {}
 }
 

--- a/tests/src/integration/integration.hpp
+++ b/tests/src/integration/integration.hpp
@@ -23,6 +23,27 @@
 #include "test_utils.hpp"
 #include "values.hpp"
 
+// Macros for grouping tests together
+#define GROUP_TEST_F(group_name, test_case, test_name) \
+  TEST_F(test_case, group_name##_##test_name)
+#define GROUP_TYPED_TEST_P(group_name, test_case, test_name) \
+  TYPED_TEST_P(test_case, group_name##_##test_name)
+
+// Macros to use for grouping integration tests together
+#define GROUP_INTEGRATION_TEST(server_type) \
+  GROUP_CONCAT(Integration, server_type)
+#define INTEGRATION_TEST_F(server_type, test_case, test_name) \
+  GROUP_TEST_F(Integration##_##server_type, test_case, test_name)
+#define INTEGRATION_TYPED_TEST_P(server_type, test_case, test_name) \
+  GROUP_TYPED_TEST_P(Integration##_##server_type, test_case, test_name)
+
+// Macros to use for grouping Cassandra integration tests together
+#define CASSANDRA_TEST_NAME(test_name) Integration##_##Cassandra##_##test_name
+#define CASSANDRA_INTEGRATION_TEST_F(test_case, test_name) \
+  INTEGRATION_TEST_F(Cassandra, test_case, test_name)
+#define CASSANDRA_INTEGRATION_TYPED_TEST_P(test_case, test_name) \
+  INTEGRATION_TYPED_TEST_P(Cassandra, test_case, test_name)
+
 #define SKIP_TEST(message) \
   std::cout << "[ SKIPPED  ] " << message << std::endl; \
   return;
@@ -200,6 +221,38 @@ protected:
   std::string test_name_;
 
   /**
+   * Get the default keyspace name (based on the current test case and test
+   * name)
+   *
+   * @return Default keyspace name
+   */
+  virtual std::string default_keyspace();
+
+  /**
+   * Get the default replication factor (based on the number of nodes in the
+   * standard two data center configuration for the test harness)
+   *
+   * @return Default replication factor
+   */
+  virtual unsigned short default_replication_factor();
+
+  /**
+   * Get the default replication strategy for the keyspace (based on the
+   * default replication factor or the overridden value assigned during the test
+   * case setup process)
+   *
+   * @return  Default replication strategy
+   */
+  virtual std::string default_replication_strategy();
+
+  /**
+   * Get the default table name (based on the test name)
+   *
+   * @return  Default table name
+   */
+  virtual std::string default_table();
+
+  /**
    * Establish the session connection using provided cluster object.
    *
    * @param cluster Cluster object to use when creating session connection
@@ -275,7 +328,6 @@ protected:
     return duration;
   }
 
-protected:
   /**
    * Get the current working directory
    *

--- a/tests/src/integration/main.cpp
+++ b/tests/src/integration/main.cpp
@@ -12,6 +12,7 @@
 #include "win_debug.hpp"
 
 #include "dse.h"
+#include "test_utils.hpp"
 
 #include <ostream>
 
@@ -19,40 +20,96 @@
  * Bootstrap listener for handling start and end of the integration tests.
  */
 class BootstrapListener : public testing::EmptyTestEventListener {
+public:
+  BootstrapListener()
+    : is_settings_displayed_(false) {}
+
+  /**
+   * Set the current test category being executed
+   *
+   * @param category Current category
+   */
+  void set_category(TestCategory category) {
+    category_ = category;
+  }
+
   void OnTestProgramStart(const testing::UnitTest& unit_test) {
-    std::cout << "Starting DataStax C/C++ Driver Integration Test" << std::endl;
-    std::cout << "  Cassandra driver v"
-              << CASS_VERSION_MAJOR << "."
-              << CASS_VERSION_MINOR << "."
-              << CASS_VERSION_PATCH;
-    if (!std::string(CASS_VERSION_SUFFIX).empty()) {
-      std::cout << "-" << CASS_VERSION_SUFFIX;
+    if (!is_settings_displayed_) {
+      std::cout << "Starting DataStax C/C++ Driver Integration Test" << std::endl;
+      std::cout << "  Cassandra driver v"
+                << CASS_VERSION_MAJOR << "."
+                << CASS_VERSION_MINOR << "."
+                << CASS_VERSION_PATCH;
+      if (!std::string(CASS_VERSION_SUFFIX).empty()) {
+        std::cout << "-" << CASS_VERSION_SUFFIX;
+      }
+      std::cout << std::endl << "  DSE driver v"
+                << DSE_VERSION_MAJOR << "."
+                << DSE_VERSION_MINOR << "."
+                << DSE_VERSION_PATCH;
+      if (!std::string(DSE_VERSION_SUFFIX).empty()) {
+        std::cout << "-" << DSE_VERSION_SUFFIX;
+      }
+      std::cout << std::endl << "  libuv v" << uv_version_string() << std::endl;
+      Options::print_settings();
+      is_settings_displayed_ = true;
     }
-    std::cout << std::endl << "  DSE driver v"
-              << DSE_VERSION_MAJOR << "."
-              << DSE_VERSION_MINOR << "."
-              << DSE_VERSION_PATCH;
-    if (!std::string(DSE_VERSION_SUFFIX).empty()) {
-      std::cout << "-" << DSE_VERSION_SUFFIX;
-    }
-    std::cout << std::endl;
-    Options::print_settings();
     Options::ccm()->remove_all_clusters();
+    std::cout << "Category: " << category_ << std::endl;
   }
 
   void OnTestProgramEnd(const testing::UnitTest& unit_test) {
-    std::cout << "Finishing DataStax C/C++ Driver Integration Test" << std::endl;
+    std::cout << std::endl;
     Options::ccm()->remove_all_clusters();
   }
+
+private:
+  /**
+   * Current category
+   */
+  TestCategory category_;
+  /**
+   * Flag to determine if the settings have been displayed
+   */
+  bool is_settings_displayed_;
 };
+
+/**
+ * Generate the entire filter pattern which includes the base filter applied and
+ * the exclusion filter based on the given category
+ *
+ * @param category Category that should be enabled
+ * @param base_filter Base filter being applied to exclusion
+ * @return Filter pattern to execute for the given category
+ */
+std::string generate_filter(TestCategory category,
+  const std::string& base_filter) {
+  // Create the exclusion filter by iterating over the available categories
+  std::string exclude_filter;
+  for (TestCategory::iterator iterator = TestCategory::begin();
+    iterator != TestCategory::end(); ++iterator) {
+    if (category != *iterator) {
+      exclude_filter += ":" + iterator->filter();
+    }
+  }
+
+  // Determine if the negative pattern should be applied
+  if (!exclude_filter.empty() && !test::Utils::contains(base_filter, "-")) {
+    exclude_filter.insert(1, "-");
+  }
+
+  //
+  return base_filter + exclude_filter;
+}
 
 int main(int argc, char* argv[]) {
   // Initialize the Google testing framework
   testing::InitGoogleTest(&argc, argv);
 
   // Add a bootstrap mechanism for program start and finish
+  BootstrapListener* listener = NULL;
   testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
-  listeners.Append(new BootstrapListener());
+  listeners.Append(listener = new BootstrapListener());
 
 #if defined(_WIN32) && defined(_DEBUG)
   // Add the memory leak checking to the listener callbacks
@@ -64,8 +121,25 @@ int main(int argc, char* argv[]) {
 #endif
 
   // Initial the options for the integration test
-  Options::initialize(argc, argv);
+  if (Options::initialize(argc, argv)) {
+    // Run the integration tests from each applicable category
+    int exit_status = 0;
+    const std::string base_filter = ::testing::GTEST_FLAG(filter);
+    std::set<TestCategory> categories = Options::categories();
+    for (std::set<TestCategory>::iterator iterator = categories.begin();
+      iterator != categories.end(); ++iterator) {
+      // Update the filtering based on the current category
+      ::testing::GTEST_FLAG(filter) = generate_filter(*iterator, base_filter);
+      listener->set_category(*iterator);
 
-  // Run the integration tests
-  return RUN_ALL_TESTS();
+      // Execute the current category and determine if a failure occurred
+      if (0 != RUN_ALL_TESTS()) {
+        exit_status = 1;
+      }
+    }
+    //TODO: Write a custom start and end report for all categories executed
+    std::cout << "Finishing DataStax C/C++ Driver Integration Test" << std::endl;
+    return exit_status;
+  }
+  return Options::is_help() ? 0 : 1;
 }

--- a/tests/src/integration/next_host_retry_policy.cpp
+++ b/tests/src/integration/next_host_retry_policy.cpp
@@ -1,0 +1,40 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+#include "next_host_retry_policy.hpp"
+
+NextHostRetryPolicy::NextHostRetryPolicy()
+  : cass::DefaultRetryPolicy() {}
+
+test::driver::RetryPolicy NextHostRetryPolicy::policy() {
+  cass::RetryPolicy* policy = new NextHostRetryPolicy();
+  policy->inc_ref();
+  return CassRetryPolicy::to(policy);
+}
+
+cass::RetryPolicy::RetryDecision NextHostRetryPolicy::on_read_timeout(
+  const cass::Request* request, CassConsistency cl, int received, int required,
+  bool data_recevied, int num_retries) const {
+  return RetryDecision::retry_next_host(cl);
+}
+
+cass::RetryPolicy::RetryDecision NextHostRetryPolicy::on_write_timeout(
+  const cass::Request* request, CassConsistency cl, int received, int required,
+  CassWriteType write_type, int num_retries) const {
+  return RetryDecision::retry_next_host(cl);
+}
+
+cass::RetryPolicy::RetryDecision NextHostRetryPolicy::on_unavailable(
+  const cass::Request* request, CassConsistency cl, int required, int alive,
+  int num_retries) const {
+  return RetryDecision::retry_next_host(cl);
+}
+
+cass::RetryPolicy::RetryDecision NextHostRetryPolicy::on_request_error(
+  const cass::Request* request, CassConsistency cl,
+  const cass::ErrorResponse* error, int num_retries) const {
+  return RetryDecision::retry_next_host(cl);
+}

--- a/tests/src/integration/next_host_retry_policy.hpp
+++ b/tests/src/integration/next_host_retry_policy.hpp
@@ -1,0 +1,45 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __NEXT_HOST_RETRY_POLICY_HPP__
+#define __NEXT_HOST_RETRY_POLICY_HPP__
+
+#include "objects/retry_policy.hpp"
+
+#include "retry_policy.hpp"
+
+/**
+ * Retry policy that will retry the statement on the next host
+ */
+class NextHostRetryPolicy : public cass::DefaultRetryPolicy {
+public:
+  /**
+   * Create an instance of the retry policy for use with the driver
+   *
+   * @return Driver ready retry policy
+   */
+  static test::driver::RetryPolicy policy();
+
+  RetryDecision on_read_timeout(const cass::Request* request,
+    CassConsistency cl, int received, int required, bool data_recevied,
+    int num_retries) const;
+  RetryDecision on_write_timeout(const cass::Request* request,
+    CassConsistency cl, int received, int required, CassWriteType write_type,
+    int num_retries) const;
+  virtual RetryDecision on_unavailable(const cass::Request* request,
+    CassConsistency cl, int required, int alive, int num_retries) const;
+  virtual RetryDecision on_request_error(const cass::Request* request,
+    CassConsistency cl, const cass::ErrorResponse* error, int num_retries) const;
+
+private:
+  /**
+   * Private constructor to allow for opaque external pointer implementation
+   */
+  NextHostRetryPolicy();
+};
+
+#endif // __NEXT_HOST_RETRY_POLICY_HPP__

--- a/tests/src/integration/objects.hpp
+++ b/tests/src/integration/objects.hpp
@@ -14,6 +14,7 @@
 #include "objects/iterator.hpp"
 #include "objects/prepared.hpp"
 #include "objects/result.hpp"
+#include "objects/retry_policy.hpp"
 #include "objects/rows.hpp"
 #include "objects/session.hpp"
 #include "objects/statement.hpp"

--- a/tests/src/integration/objects/cluster.hpp
+++ b/tests/src/integration/objects/cluster.hpp
@@ -82,6 +82,21 @@ public:
   }
 
   /**
+   * Assign the number of connections made to each node/server for each
+   * connections thread
+   *
+   * NOTE: One extra connection is established (the control connection)
+   *
+   * @param connections Number of connection per host (default: 1)
+   * @return Cluster object
+   */
+  Cluster& with_core_connections_per_host(unsigned int connections = 1) {
+    EXPECT_EQ(CASS_OK, cass_cluster_set_core_connections_per_host(get(),
+      connections));
+    return *this;
+  }
+
+  /**
    * Enable/Disable the use of hostname resolution
    *
    * This is useful for authentication (Kerberos) or encryption (SSL)

--- a/tests/src/integration/objects/dse_graph_result_set.hpp
+++ b/tests/src/integration/objects/dse_graph_result_set.hpp
@@ -109,7 +109,7 @@ public:
     if (!future_) {
       throw Exception("Future is invalid or was not used to create instance");
     }
-    return future_.host_address();
+    return future_.host();
   }
 
   /**

--- a/tests/src/integration/objects/future.hpp
+++ b/tests/src/integration/objects/future.hpp
@@ -8,9 +8,10 @@
 #ifndef __TEST_FUTURE_HPP__
 #define __TEST_FUTURE_HPP__
 #include "cassandra.h"
-#include "testing.hpp"
 
 #include "objects/object_base.hpp"
+
+#include "driver_utils.hpp"
 
 #include <string>
 
@@ -47,6 +48,15 @@ public:
     : Object<CassFuture, cass_future_free>(future) {}
 
   /**
+   * Get the attempted hosts/addresses of the future (sorted)
+   *
+   * @return Attempted hosts/Addresses (sorted)
+   */
+  const std::vector<std::string> attempted_hosts() {
+    return test::driver::internals::Utils::attempted_hosts(get());
+  }
+
+  /**
    * Get the error code from the future
    *
    * @return Error code of the future
@@ -77,12 +87,12 @@ public:
   }
 
   /**
-   * Get the host address of the future
+   * Get the host/address of the future
    *
-   * @return Host address
+   * @return Host/Address
    */
-  const std::string host_address() {
-    return cass::get_host_from_future(get());
+  const std::string host() {
+    return test::driver::internals::Utils::host(get());
   }
 
   /**

--- a/tests/src/integration/objects/result.hpp
+++ b/tests/src/integration/objects/result.hpp
@@ -54,6 +54,15 @@ public:
     , future_(future) {}
 
   /**
+   * Get the attempted host/address of the future
+   *
+   * @return Attempted host/address
+   */
+  const std::vector<std::string> attempted_hosts() {
+    return future_.attempted_hosts();
+  }
+
+  /**
    * Get the error code from the future
    *
    * @return Error code of the future
@@ -78,6 +87,15 @@ public:
    */
   const std::string error_message() {
     return future_.error_message();
+  }
+
+  /**
+   * Get the host/address of the future
+   *
+   * @return Host/Address
+   */
+  const std::string host() {
+    return future_.host();
   }
 
   /**

--- a/tests/src/integration/objects/retry_policy.hpp
+++ b/tests/src/integration/objects/retry_policy.hpp
@@ -1,0 +1,70 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __TEST_RETRY_POLICY_HPP__
+#define __TEST_RETRY_POLICY_HPP__
+#include "cassandra.h"
+
+#include "objects/object_base.hpp"
+
+namespace test {
+namespace driver {
+
+/**
+ * Wrapped retry policy object
+ */
+class RetryPolicy : public Object<CassRetryPolicy, cass_retry_policy_free> {
+public:
+  /**
+   * Create the retry policy object from the native driver retry policy object
+   *
+   * @param retry_policy Native driver object
+   */
+  RetryPolicy(CassRetryPolicy* retry_policy)
+    : Object<CassRetryPolicy, cass_retry_policy_free>(retry_policy) {}
+
+  /**
+   * Create the retry policy object from the shared reference
+   *
+   * @param retry_policy Shared reference
+   */
+  RetryPolicy(Ptr retry_policy)
+    : Object<CassRetryPolicy, cass_retry_policy_free>(retry_policy) {}
+};
+
+/**
+ * Wrapped default retry policy
+ */
+class DefaultRetryPolicy : public RetryPolicy {
+public:
+  /**
+   * Create the default retry policy object from the native driver default retry
+   * policy object
+   */
+  DefaultRetryPolicy()
+    : RetryPolicy(cass_retry_policy_default_new()) {}
+};
+
+/**
+ * Wrapped logging retry policy
+ */
+class LoggingRetryPolicy : public RetryPolicy {
+public:
+  /**
+   * Create the logging retry policy object from the native driver logging retry
+   * policy object with the given child policy
+   *
+   * @param child_policy Child retry policy being logged (CASS_LOG_INFO)
+   */
+  LoggingRetryPolicy(RetryPolicy child_policy)
+    : RetryPolicy(cass_retry_policy_logging_new(child_policy.get())) {}
+};
+
+} // namespace driver
+} // namespace test
+
+#endif // __TEST_RETRY_POLICY_HPP__

--- a/tests/src/integration/objects/session.hpp
+++ b/tests/src/integration/objects/session.hpp
@@ -98,16 +98,18 @@ public:
    * @param query Query to execute as a simple statement
    * @param consistency Consistency level to execute the query at
    *                    (default: CASS_CONSISTENCY_LOCAL_ONE)
+   * @param is_idempotent True if statement is idempotent; false otherwise
+   *                      (default: false)
    * @param assert_ok True if error code for future should be asserted
    *                  CASS_OK; false otherwise (default: true)
    * @return Result object
    */
   Result execute(const std::string& query,
     CassConsistency consistency = CASS_CONSISTENCY_LOCAL_ONE,
-    bool assert_ok = true) {
-    Statement statement(cass_statement_new(query.c_str(), 0));
-    EXPECT_EQ(CASS_OK, cass_statement_set_consistency(statement.get(),
-      consistency));
+    bool is_idempotent = false, bool assert_ok = true) {
+    Statement statement(query);
+    statement.set_consistency(consistency);
+    statement.set_idempotent(is_idempotent);
     return execute(statement, assert_ok);
   }
 
@@ -137,13 +139,16 @@ public:
    * @param query Query to execute as a simple statement
    * @param consistency Consistency level to execute the query at
    *                    (default: CASS_CONSISTENCY_LOCAL_ONE)
+   * @param is_idempotent True if statement is idempotent; false otherwise
+   *                      (default: false)
    * @return Future object
    */
   Future execute_async(const std::string& query,
-    CassConsistency consistency = CASS_CONSISTENCY_LOCAL_ONE) {
-    Statement statement(cass_statement_new(query.c_str(), 0));
-    EXPECT_EQ(CASS_OK, cass_statement_set_consistency(statement.get(),
-      consistency));
+    CassConsistency consistency = CASS_CONSISTENCY_LOCAL_ONE,
+    bool is_idempotent = false) {
+    Statement statement(query);
+    statement.set_consistency(consistency);
+    statement.set_idempotent(is_idempotent);
     return execute_async(statement);
   }
 

--- a/tests/src/integration/objects/statement.hpp
+++ b/tests/src/integration/objects/statement.hpp
@@ -12,6 +12,11 @@
 #include "objects/object_base.hpp"
 
 #include "objects/future.hpp"
+#include "objects/retry_policy.hpp"
+
+#include "driver_utils.hpp"
+
+#include <gtest/gtest.h>
 
 namespace test {
 namespace driver {
@@ -42,9 +47,11 @@ public:
    *
    * @param query Query to create statement from
    * @param parameter_count Number of parameters contained in the query
+   *                        (default: 0)
    */
-  Statement(const std::string& query, size_t parameter_count)
-    : Object<CassStatement, cass_statement_free>(cass_statement_new(query.c_str(), parameter_count)) {}
+  Statement(const std::string& query, size_t parameter_count = 0)
+    : Object<CassStatement, cass_statement_free>(cass_statement_new(query.c_str(),
+      parameter_count)) {}
 
   /**
    * Bind a value to the statement
@@ -55,6 +62,48 @@ public:
   template<typename T>
   void bind(size_t index, T value) {
     value.statement_bind(*this, index);
+  }
+
+  /**
+   * Assign/Set the statement's consistency level
+   *
+   * @param cosnsitency Consistency to use for the statement
+   */
+  void set_consistency(CassConsistency consistency) {
+    ASSERT_EQ(CASS_OK, cass_statement_set_consistency(get(), consistency));
+  }
+
+  /**
+   * Enable/Disable whether the statement is idempotent. Idempotent statements
+   * are able to be automatically retried after timeouts/errors and can be
+   * speculatively executed.
+   *
+   * @param enable True if statement is idempotent; false otherwise
+   */
+  void set_idempotent(bool enable) {
+    ASSERT_EQ(CASS_OK, cass_statement_set_is_idempotent(get(),
+      enable ? cass_true : cass_false));
+  }
+
+  /**
+   * Enable/Disable the statement's recording of hosts attempted during its
+   * execution
+   *
+   * @param enable True if attempted host should be recorded; false otherwise
+   */
+  void set_record_attempted_hosts(bool enable) {
+    return test::driver::internals::Utils::set_record_attempted_hosts(get(),
+      enable);
+  }
+
+  /**
+   * Assign/Set the statement's retry policy
+   *
+   * @param retry_policy Retry policy to use for the statement
+   */
+  void set_retry_policy(RetryPolicy retry_policy) {
+    ASSERT_EQ(CASS_OK, cass_statement_set_retry_policy(get(),
+      retry_policy.get()));
   }
 };
 
@@ -102,10 +151,39 @@ public:
         << "Unable to Add Statement to Batch: " << cass_error_desc(error_code);
     }
   }
+
+  /**
+   * Assign/Set the batch's consistency level
+   *
+   * @param cosnsitency Consistency to use for the batch
+   */
+  void set_consistency(CassConsistency consistency) {
+    ASSERT_EQ(CASS_OK, cass_batch_set_consistency(get(), consistency));
+  }
+
+  /**
+   * Enable/Disable whether the statements in a batch are idempotent. Idempotent
+   * batches are able to be automatically retried after timeouts/errors and can
+   * be speculatively executed.
+   *
+   * @param enable True if statement in a batch is idempotent; false otherwise
+   */
+  void set_idempotent(bool enable) {
+    ASSERT_EQ(CASS_OK, cass_batch_set_is_idempotent(get(),
+      enable ? cass_true : cass_false));
+  }
+
+  /**
+   * Assign/Set the batch's retry policy
+   *
+   * @param retry_policy Retry policy to use for the batch
+   */
+  void set_retry_policy(RetryPolicy retry_policy) {
+    ASSERT_EQ(CASS_OK, cass_batch_set_retry_policy(get(), retry_policy.get()));
+  }
 };
 
 } // namespace driver
 } // namespace test
 
 #endif // __TEST_STATEMENT_HPP__
-

--- a/tests/src/integration/options.cpp
+++ b/tests/src/integration/options.cpp
@@ -14,8 +14,8 @@
 #include <algorithm>
 #include <iostream>
 
-#define DEFAULT_OPTIONS_CASSSANDRA_VERSION CCM::CassVersion("3.7")
-#define DEFAULT_OPTIONS_DSE_VERSION CCM::DseVersion("5.0.2")
+#define DEFAULT_OPTIONS_CASSSANDRA_VERSION CCM::CassVersion("3.9")
+#define DEFAULT_OPTIONS_DSE_VERSION CCM::DseVersion("5.0.3")
 
 // Initialize the defaults for all the options
 bool Options::is_initialized_ = false;

--- a/tests/src/integration/options.hpp
+++ b/tests/src/integration/options.hpp
@@ -8,7 +8,9 @@
 #ifndef __OPTIONS_HPP__
 #define __OPTIONS_HPP__
 #include "bridge.hpp"
+#include "exception.hpp"
 #include "shared_ptr.hpp"
+#include "test_category.hpp"
 
 #include <string>
 
@@ -27,17 +29,20 @@ public:
    *         or there was an issue parsing the command line arguments.
    */
   static bool initialize(int argc, char* argv[]);
-
   /**
    * Print the help message for the options
    */
   static void print_help();
-
   /**
    * Print the settings message for the options
    */
   static void print_settings();
-
+  /**
+   * Flag to determine if the help flag was indicated
+   *
+   * @return True if help was indicated; false otherwise
+   */
+  static bool is_help();
   /**
    * Flag to determine if integration tests should log the driver logs to a file
    * for each test
@@ -45,91 +50,84 @@ public:
    * @return True if tests should be logged to a file; false otherwise
    */
   static bool log_tests();
-
   /**
    * Get the server version (Cassandra/DSE) to use
    *
    * @return Cassandra/DSE version to use
    */
   static CCM::CassVersion server_version();
-
   /**
    * Flag to determine if DSE should be used or not
    *
    * @return True if DSE should be used; false otherwise
    */
   static bool is_dse();
-
   /**
    * Get the DSE credentials type (username|password/INI file)
    *
    * @return DSE credentials type
    */
   static CCM::DseCredentialsType dse_credentials();
-
   /**
    * Get the username for SSH authentication
    *
    * @return Username for remote deployment
    */
   static const std::string& dse_username();
-
   /**
    * Get the password for SSH authentication
    *
    * @return Password for remote deployment
    */
   static const std::string& dse_password();
-
   /**
    * Flag to determine if Cassandra/DSE should be built from ASF/GitHub
    *
    * @return True if ASF/GitHub should be used; false otherwise
    */
   static bool use_git();
-
   /**
    * Get the branch/tag to use for ASF/GitHub
    *
    * @return Branch/Tag
    */
   static const std::string& branch_tag();
-
   /**
    * Flag to determine if installation directory should be used (Passed to CCM)
    *
    * @return True if installation directory should be used; false otherwise
    */
   static bool use_install_dir();
-
   /**
    * Get the installation directory to use
    *
    * @return Installation directory
    */
   static const std::string& install_dir();
-
   /**
    * Get the cluster prefix to use for the CCM clusters (e.g. cpp-driver)
    *
    * @return Cluster prefix
    */
   static const std::string& cluster_prefix();
-
   /**
    * Get the deployment type (local|remote)
    *
    * @return Deployment type
    */
   static CCM::DeploymentType deployment_type();
-
   /**
    * Get the authentication type for remote deployment
    *
    * @return Authentication type
    */
   static CCM::AuthenticationType authentication_type();
-
+  /**
+   * Get the test categories being applied
+   *
+   * @return Test categories being applied
+   */
+  static std::set<TestCategory> categories();
   /**
    * Get the IP address to use when establishing SSH connection for remote CCM
    * command execution and/or IP address to use for server connection IP
@@ -138,42 +136,36 @@ public:
    * @return Host to use for server (and SSH connection for remote deployment)
    */
   static const std::string& host();
-
   /**
    * Get the TCP/IP port for SSH connection
    *
    * @return SSH port to use
    */
   static short port();
-
   /**
    * Get the username for SSH authentication
    *
    * @return Username for remote deployment
    */
   static const std::string& username();
-
   /**
    * Get the password for SSH authentication
    *
    * @return Password for remote deployment
    */
   static const std::string& password();
-
   /**
    * Get the public key for SSH authentication
    *
    * @return Public key for remote deployment
    */
   static const std::string& public_key();
-
   /**
    * Get the private key for SSH authentication
    *
    * @return Private key for remote deployment
    */
   static const std::string& private_key();
-
   /**
    * Get a CCM instance based on the options
    *
@@ -186,6 +178,10 @@ private:
    * Flag to determine if the options have been initialized
    */
   static bool is_initialized_;
+  /**
+   * Flag to determine if the help flag was indicated
+   */
+  static bool is_help_;
   /**
    * Flag to indicate if log messages should be generated for each test
    */
@@ -245,6 +241,10 @@ private:
    */
   static CCM::DeploymentType deployment_type_;
   /**
+   * Test types (Cassandra|DSE|SCassandra)
+   */
+  static std::set<TestCategory> categories_;
+  /**
    * IP address to use when establishing SSH connection for remote CCM command
    * execution and/or IP address to use for server connection IP generation
    */
@@ -276,24 +276,12 @@ private:
    * Hidden default constructor
    */
   Options();
-
   /**
-   * Convert a string to lowercase
+   * Get the boolean value of a string
    *
-   * @param input String to convert to lowercase
+   * @param value Value to convert to boolean
+   * @return True if value is yes, true, on, or 0; false otherwise
    */
-  static std::string to_lower(const std::string& input);
-
-  /**
-  * Split a string into an array/vector
-  *
-  * @param input String to convert to array/vector
-  * @param delimiter Character to use split into elements (default: <space>)
-  * @return An array/vector representation of the string
-  */
-  static std::vector<std::string> explode(const std::string& input,
-    const char delimiter = ' ');
-
   static bool bool_value(const std::string& value);
 };
 

--- a/tests/src/integration/scassandra/priming_requests.hpp
+++ b/tests/src/integration/scassandra/priming_requests.hpp
@@ -1,0 +1,429 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __PRIMING_REQUEST_HPP__
+#define __PRIMING_REQUEST_HPP__
+
+#include "exception.hpp"
+#include "priming_result.hpp"
+#include "priming_rows.hpp"
+
+#include "cassandra.h"
+
+#include <set>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+/**
+ * Priming request
+ */
+class PrimingRequest {
+public:
+  class Exception : public test::Exception {
+  public:
+    Exception(const std::string& message)
+      : test::Exception(message) {}
+  };
+
+  /**
+   * Builder instantiation of the PrimingRequest object
+   *
+   * @return PrimingRequest instance
+   */
+  static PrimingRequest builder() {
+    return PrimingRequest();
+  }
+
+  /**
+   * Generate the JSON for the priming request
+   *
+   * @return JSON representing the priming request
+   */
+  std::string json() {
+    // Initialize the rapid JSON writer
+    rapidjson::StringBuffer buffer;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> json(buffer);
+
+    // Build the JSON object (priming request)
+    json.StartObject();
+    when_.build(&json);
+    then_.build(&json);
+    json.EndObject();
+    return buffer.GetString();
+  }
+
+  /**
+   * Set a fixed delay to the response time of a request
+   *
+   * @param fixed_delay Delay in milliseconds before responding to the request
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_fixed_delay(const unsigned long fixed_delay_ms) {
+    then_.with_fixed_delay(fixed_delay_ms);
+    return *this;
+  }
+
+  /**
+   * Set a response for the request
+   *
+   * @param result Response to the request
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_result(const PrimingResult& result) {
+    then_.with_result(result);
+    return *this;
+  }
+
+  /**
+   * Set the rows to the return in the response of the request
+   *
+   * @param rows Rows to return when responding to the request
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_rows(const PrimingRows& rows) {
+    then_.with_rows(rows);
+    return *this;
+  }
+
+  /**
+   * Add a consistency level that is valid for the request
+   *
+   * @param consistency Consistency level
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_consistency(const CassConsistency consistency) {
+    when_.with_consistency(consistency);
+    return *this;
+  }
+
+  /**
+   * Set the consistency levels that are valid for the request
+   *
+   * @param consistency Consistency levels for the request
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_consistency(
+    const std::vector<CassConsistency>& consistency) {
+    when_.with_consistency(consistency);
+    return *this;
+  }
+
+  /**
+   * Set the keyspace for the request
+   *
+   * @param keyspace Name of the keyspace
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_keyspace(const std::string& keyspace) {
+    when_.with_keyspace(keyspace);
+    return *this;
+  }
+
+  /**
+   * Set the query for the request
+   *
+   * @param query Query for the request
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_query(const std::string& query) {
+    when_.with_query(query);
+    return *this;
+  }
+
+  /**
+   * Set the query pattern (regex) for the request
+   *
+   * @param query_pattern Query pattern for the request
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_query_pattern(const std::string& query_pattern) {
+    when_.with_query_pattern(query_pattern);
+    return *this;
+   }
+
+  /**
+   * Set the table for the request
+   *
+   * @param table Name of the table
+   * @return PrimingRequest instance
+   */
+  PrimingRequest& with_table(const std::string& table) {
+    when_.with_table(table);
+    return *this;
+  }
+
+private:
+  class Then {
+  friend class PrimingRequest;
+  private:
+    /**
+     * Fixed delay (in milliseconds)
+     */
+    unsigned long fixed_delay_ms_;
+    /**
+     * Result
+     */
+    PrimingResult result_;
+    /**
+     * Rows
+     */
+    PrimingRows rows_;
+
+    Then()
+      : fixed_delay_ms_(0)
+      , result_(PrimingResult::SUCCESS) {};
+
+    /**
+     * Build the then section for the priming request
+     *
+     * @param writer JSON writer to add the column types to
+     */
+    void build(rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) {
+      // Initialize the then JSON object
+      writer->Key("then");
+      writer->StartObject();
+
+
+      // Determine if the fixed delay JSON object should be added
+      if (fixed_delay_ms_ > 0) {
+        writer->Key("fixedDelay");
+        writer->Uint64(fixed_delay_ms_);
+      }
+
+      // Add the result JSON object
+      writer->Key("result");
+      writer->String(result_.json_value().c_str());
+
+      // Determine if the rows and column types JSON objects should be added
+      if (!rows_.empty()) {
+        rows_.build_rows(writer);
+        rows_.build_column_types(writer);
+      }
+
+      // Finalize the then JSON object
+      writer->EndObject();
+    }
+
+    /**
+     * Set a fixed delay to the response time of a request
+     *
+     * @param fixed_delay Delay in milliseconds before responding to the request
+     */
+    void with_fixed_delay(const unsigned long fixed_delay) {
+      fixed_delay_ms_ = fixed_delay;
+    }
+
+    /**
+     * Set a response for the request
+     *
+     * @param result Response to the request
+     */
+    void with_result(const PrimingResult& result) {
+      result_ = result;
+    }
+
+    /**
+     * Set the rows to the return in the response of the request
+     *
+     * @param rows Rows to return when responding to the request
+     */
+    void with_rows(const PrimingRows& rows) {
+      rows_ = rows;
+    }
+  };
+
+  class When {
+  friend class PrimingRequest;
+  private:
+    /**
+     * Consistency levels
+     */
+    std::vector<CassConsistency> consistency_;
+    /**
+     * Keyspace name
+     */
+    std::string keyspace_;
+    /**
+     * Query
+     */
+    std::string query_;
+    /**
+     * Query pattern
+     */
+    std::string query_pattern_;
+    /**
+     * Table name
+     */
+    std::string table_;
+
+    When() {};
+
+    /**
+     * Build the when section for the priming request
+     *
+     * @param writer JSON writer to add the column types to
+     * @throws PrimingRequest::Exception If query and query pattern are present
+     */
+    void build(rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) {
+      // Determine if an exception should be thrown
+      if (!query_.empty() && !query_pattern_.empty()) {
+        throw PrimingRequest::Exception("Unable to Build WHEN: Query and query "
+          "pattern can not be used at the same time");
+      }
+
+      // Initialize the when JSON object
+      writer->Key("when");
+      writer->StartObject();
+
+      // Determine if the consistency JSON object should be added
+      if (!consistency_.empty()) {
+        writer->Key("consistency");
+        writer->StartArray();
+        for (std::vector<CassConsistency>::iterator iterator = consistency_.begin();
+          iterator != consistency_.end(); ++iterator) {
+          writer->String(get_cql_consistency(*iterator).c_str());
+        }
+        writer->EndArray();
+      }
+
+      // Determine if the keyspace JSON object should be added
+      if (!keyspace_.empty()) {
+        writer->Key("keyspace");
+        writer->String(keyspace_.c_str());
+      }
+
+      // Determine if the query JSON object should be added
+      if (!query_.empty()) {
+        writer->Key("query");
+        writer->String(query_.c_str());
+      }
+
+      // Determine if the query pattern JSON object should be added
+      if (!query_pattern_.empty()) {
+        writer->Key("queryPattern");
+        writer->String(query_pattern_.c_str());
+      }
+
+      // Determine if the table JSON object should be added
+      if (!table_.empty()) {
+        writer->Key("table");
+        writer->String(table_.c_str());
+      }
+
+      // Finalize the when JSON object
+      writer->EndObject();
+    }
+
+    /**
+     * Add a consistency level that is valid for the request
+     *
+     * @param consistency Consistency level
+     */
+    void with_consistency(const CassConsistency consistency) {
+      consistency_.push_back(consistency);
+    }
+
+    /**
+     * Set the consistency levels that are valid for the request
+     *
+     * @param consistency Consistency levels for the request
+     */
+    void with_consistency(
+      const std::vector<CassConsistency>& consistency) {
+      consistency_ = consistency;
+    }
+
+    /**
+     * Set the keyspace for the request
+     *
+     * @param keyspace Name of the keyspace
+     */
+    void with_keyspace(const std::string& keyspace) {
+      keyspace_ = keyspace;
+    }
+
+    /**
+     * Set the query for the request
+     *
+     * @param query Query for the request
+     */
+    void with_query(const std::string& query) {
+      query_ = query;
+    }
+
+    /**
+     * Set the query pattern (regex) for the request
+     *
+     * @param query_pattern Query pattern for the request
+     */
+    void with_query_pattern(const std::string& query_pattern) {
+      query_pattern_ = query_pattern;
+    }
+
+    /**
+     * Set the table for the request
+     *
+     * @param table Name of the table
+     */
+    void with_table(const std::string& table) {
+      table_ = table;
+    }
+
+    /**
+     * Convert the driver consistency level to a value for the priming request
+     *
+     * @param consistency Consistency level
+     * @return String representation of the consistency level
+     */
+    std::string get_cql_consistency(CassConsistency consistency) const {
+      switch(consistency) {
+        case CASS_CONSISTENCY_ANY:
+          return "ANY";
+        case CASS_CONSISTENCY_ONE:
+          return "ONE";
+        case CASS_CONSISTENCY_TWO:
+          return "TWO";
+        case CASS_CONSISTENCY_THREE:
+          return "THREE";
+        case CASS_CONSISTENCY_QUORUM:
+          return "QUORUM";
+        case CASS_CONSISTENCY_ALL:
+          return "ALL";
+        case CASS_CONSISTENCY_LOCAL_QUORUM:
+          return "LOCAL_QUORUM";
+        case CASS_CONSISTENCY_EACH_QUORUM:
+          return "EACH_QUORUM";
+        case CASS_CONSISTENCY_SERIAL:
+          return "SERIAL";
+        case CASS_CONSISTENCY_LOCAL_SERIAL:
+          return "LOCAL_SERIAL";
+        case CASS_CONSISTENCY_LOCAL_ONE:
+          return "LOCAL_ONE";
+        case CASS_CONSISTENCY_UNKNOWN:
+        default:
+          throw Exception("Invalid Consistency: UNKNOWN");
+      }
+    }
+  };
+
+  /**
+   * Then portion of the priming request
+   */
+  Then then_;
+  /**
+   * When portion of the priming request
+   */
+  When when_;
+
+  /**
+   * Disallow constructor for builder pattern
+   */
+  PrimingRequest() {};
+};
+
+#endif //__PRIMING_REQUEST_HPP__

--- a/tests/src/integration/scassandra/priming_result.cpp
+++ b/tests/src/integration/scassandra/priming_result.cpp
@@ -1,0 +1,33 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#include "priming_result.hpp"
+
+const PrimingResult PrimingResult::SUCCESS("success");
+const PrimingResult PrimingResult::READ_REQUEST_TIMEOUT("request_timeout");
+const PrimingResult PrimingResult::UNAVAILABLE("unavailable");
+const PrimingResult PrimingResult::WRITE_REQUEST_TIMEOUT("write_request_timeout");
+const PrimingResult PrimingResult::SERVER_ERROR("server_error");
+const PrimingResult PrimingResult::PROTOCOL_ERROR("protocol_error");
+const PrimingResult PrimingResult::BAD_CREDENTIALS("bad_credentials");
+const PrimingResult PrimingResult::OVERLOADED("overloaded");
+const PrimingResult PrimingResult::IS_BOOTSTRAPPING("is_bootstrapping");
+const PrimingResult PrimingResult::TRUNCATE_ERROR("truncate_error");
+const PrimingResult PrimingResult::SYNTAX_ERROR("syntax_error");
+const PrimingResult PrimingResult::UNAUTHORIZED("unauthorized");
+const PrimingResult PrimingResult::INVALID("invalid");
+const PrimingResult PrimingResult::CONFIG_ERROR("config_error");
+const PrimingResult PrimingResult::ALREADY_EXISTS("already_exists");
+const PrimingResult PrimingResult::UNPREPARED("unprepared");
+const PrimingResult PrimingResult::CLOSED_CONNECTION("closed_connection");
+
+PrimingResult::PrimingResult(const std::string& json_value)
+  : json_value_(json_value) {}
+
+const std::string& PrimingResult::json_value() const {
+  return json_value_;
+}

--- a/tests/src/integration/scassandra/priming_result.hpp
+++ b/tests/src/integration/scassandra/priming_result.hpp
@@ -1,0 +1,103 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __PRIMING_RESULT_HPP__
+#define __PRIMING_RESULT_HPP__
+
+#include <string>
+
+/**
+ * Priming result request response
+ */
+class PrimingResult {
+public:
+  /**
+   * Success
+   */
+  static const PrimingResult SUCCESS;
+  /**
+   * Read request timeout
+   */
+  static const PrimingResult READ_REQUEST_TIMEOUT;
+  /**
+   * Unavailable
+   */
+  static const PrimingResult UNAVAILABLE;
+  /**
+   * Write request timeout
+   */
+  static const PrimingResult WRITE_REQUEST_TIMEOUT;
+  /**
+   * Server error
+   */
+  static const PrimingResult SERVER_ERROR;
+  /**
+   * Protocol error
+   */
+  static const PrimingResult PROTOCOL_ERROR;
+  /**
+   * Bas/Invalid credentials
+   */
+  static const PrimingResult BAD_CREDENTIALS;
+  /**
+   * Overloaded
+   */
+  static const PrimingResult OVERLOADED;
+  /**
+   * Bootstrapping
+   */
+  static const PrimingResult IS_BOOTSTRAPPING;
+  /**
+   * Truncate error
+   */
+  static const PrimingResult TRUNCATE_ERROR;
+  /**
+   * Syntax error
+   */
+  static const PrimingResult SYNTAX_ERROR;
+  /**
+   * Unauthorized
+   */
+  static const PrimingResult UNAUTHORIZED;
+  /**
+   * Invalid
+   */
+  static const PrimingResult INVALID;
+  /**
+   * Configuration error
+   */
+  static const PrimingResult CONFIG_ERROR;
+  /**
+   * Already exists
+   */
+  static const PrimingResult ALREADY_EXISTS;
+  /**
+   * Unprepared
+   */
+  static const PrimingResult UNPREPARED;
+  /**
+   * Closed connection
+   */
+  static const PrimingResult CLOSED_CONNECTION;
+
+  const std::string& json_value() const;
+
+private:
+  /**
+   * JSON value associated with the result constant
+   */
+  std::string json_value_;
+
+    /**
+   * Create the result constant for priming the result of an executed query
+   *
+   * @param json_value JSON value to associated with the constant
+   */
+  PrimingResult(const std::string& json_value);
+};
+
+#endif //__PRIMING_RESULT_HPP__

--- a/tests/src/integration/scassandra/priming_rows.hpp
+++ b/tests/src/integration/scassandra/priming_rows.hpp
@@ -1,0 +1,361 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __PRIMING_ROWS_HPP__
+#define __PRIMING_ROWS_HPP__
+
+#include "exception.hpp"
+#include "test_utils.hpp"
+
+#include "cassandra.h"
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/prettywriter.h>
+
+#include <map>
+#include <string>
+#include <sstream>
+#include <vector>
+
+/**
+ * Priming row
+ */
+class PrimingRow {
+friend class PrimingRows;
+public:
+  class Exception : public test::Exception {
+  public:
+    Exception(const std::string& message)
+      : test::Exception(message) {}
+  };
+  typedef std::pair<std::string, std::string> Column;
+
+  /**
+   * Builder instantiation of the PrimingColumns object
+   *
+   * @return PrimingRow instance
+   */
+  static PrimingRow builder() {
+    return PrimingRow();
+  }
+
+  /**
+   * Add a column|value pair
+   *
+   * @param name Column name
+   * @param value_type Value type for the column
+   * @param value Value for the column
+   * @return PrimingRow instance
+   */
+  PrimingRow& add_column(const std::string& name,
+    const CassValueType value_type, const std::string& value) {
+    std::string cql_type = get_cql_type(value_type);
+    if (value_type == CASS_VALUE_TYPE_LIST ||
+      value_type == CASS_VALUE_TYPE_MAP ||
+      value_type == CASS_VALUE_TYPE_SET) {
+      throw Exception("Value Type " + cql_type + "Needs to be Parameterized: "
+        "Use add_column(string name, string cql_value_type, string value) instead");
+     }
+
+    //TODO: Add types when supported by SCassandra
+    if (value_type == CASS_VALUE_TYPE_CUSTOM ||
+      value_type == CASS_VALUE_TYPE_UDT) {
+      throw Exception("Value Type is not Supported by SCassandra: "
+        + cql_type);
+    }
+
+    return add_column(name, cql_type, value);
+  }
+
+  /**
+   * Add a column|value pair
+   *
+   * @param name Column name
+   * @param cql_value_type Value type for the column
+   * @param value Value for the column
+   * @return PrimingRow instance
+   */
+  PrimingRow& add_column(const std::string& name,
+    const std::string& cql_value_type, const std::string& value) {
+    //TODO: Add validation (mainly for parameterized types)
+    // Ensure the column doesn't already exist
+    if (columns_.find(name) != columns_.end()) {
+      throw Exception("Unable to Add Column: Already Exists [" + name + "]");
+    }
+    columns_.insert(Pair(name, Column(cql_value_type, value)));
+    return *this;
+  }
+
+  /**
+   * Equality to check whether the columns are equal; number of columns and
+   * names only (values are ignored)
+   *
+   * @param rhs PrimingRow to compare
+   * @return True if number of columns and column name are equal; false
+   *         otherwise
+   */
+  bool operator==(const PrimingRow& rhs) const {
+    return columns_.size() == rhs.columns_.size()
+      && std::equal(columns_.begin(), columns_.end(), rhs.columns_.begin(),
+        ColumnsKeyEquality());
+  }
+  bool operator!=(const PrimingRow& rhs) const {
+    return !(*this == rhs);
+  }
+
+protected:
+  /**
+   * Build the column types for the column used by the row
+   *
+   * @param writer JSON writer to add the column types to
+   */
+  void build_column_types(
+    rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) {
+    // Initialize the column types JSON object
+    writer->Key("column_types");
+    writer->StartObject();
+
+    // Iterate over the columns and create the column types
+    for (Map::iterator iterator = columns_.begin(); iterator != columns_.end();
+      ++iterator) {
+      std::string name = iterator->first;
+      std::string cql_type = iterator->second.first;
+
+      // Add the column type
+      writer->Key(name.c_str());
+      writer->String(cql_type.c_str());
+    }
+
+    // Finalize the column types JSON object
+    writer->EndObject();
+  }
+
+  /**
+   * Build the row based on the columns
+   *
+   * @param writer JSON writer to add the row to
+   */
+  void build_row(rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) {
+    // Initialize the row JSON object
+    writer->StartObject();
+
+    // Iterate over the columns and create the row
+    for (Map::iterator iterator = columns_.begin(); iterator != columns_.end();
+      ++iterator) {
+      std::string name = iterator->first;
+      std::string value = iterator->second.second;
+
+      // Add the column|value pair
+      writer->Key(name.c_str());
+      bool is_array = value.compare(0, 1, "[")  == 0 &&
+        value.compare(value.size() - 1, 1, "]") == 0;
+      if (is_array) {
+        value = value.substr(1, value.size() - 2);
+        writer->StartArray();
+        std::vector<std::string> values = test::Utils::explode(value, ',');
+        for (std::vector<std::string>::iterator iterator = values.begin();
+          iterator != values.end(); ++iterator) {
+          writer->String((*iterator).c_str());
+        }
+        writer->EndArray();
+      } else {
+        writer->String(value.c_str());
+      }
+    }
+
+    // Finalize the row JSON object
+    writer->EndObject();
+  }
+
+private:
+  typedef std::map<std::string, Column> Map;
+  typedef std::pair<std::string, Column> Pair;
+  /**
+   * Columns
+   */
+  Map columns_;
+
+  /**
+   * Disallow constructor for builder pattern
+   */
+  PrimingRow() {};
+
+  /**
+   * Get the CQL type from the driver value type.
+   *
+   * @param type Driver value type
+   * @return String CQL representation of the type
+   */
+  std::string get_cql_type(CassValueType type) {
+    switch(type) {
+      case CASS_VALUE_TYPE_CUSTOM:
+        return "custom";
+      case CASS_VALUE_TYPE_ASCII:
+        return "ascii";
+      case CASS_VALUE_TYPE_BIGINT:
+        return "bigint";
+      case CASS_VALUE_TYPE_BLOB:
+        return "blob";
+      case CASS_VALUE_TYPE_BOOLEAN:
+        return "boolean";
+      case CASS_VALUE_TYPE_COUNTER:
+        return "counter";
+      case CASS_VALUE_TYPE_DECIMAL:
+        return "decimal";
+      case CASS_VALUE_TYPE_DOUBLE:
+        return "double";
+      case CASS_VALUE_TYPE_FLOAT:
+        return "float";
+      case CASS_VALUE_TYPE_INT:
+        return "int";
+      case CASS_VALUE_TYPE_TEXT:
+        return "text";
+      case CASS_VALUE_TYPE_TIMESTAMP:
+        return "timestamp";
+      case CASS_VALUE_TYPE_UUID:
+        return "uuid";
+      case CASS_VALUE_TYPE_VARCHAR:
+        return "varchar";
+      case CASS_VALUE_TYPE_VARINT:
+        return "varint";
+      case CASS_VALUE_TYPE_TIMEUUID:
+        return "timeuuid";
+      case CASS_VALUE_TYPE_INET:
+        return "inet";
+      case CASS_VALUE_TYPE_DATE:
+        return "date";
+      case CASS_VALUE_TYPE_TIME:
+        return "time";
+      case CASS_VALUE_TYPE_SMALL_INT:
+        return "smallint";
+      case CASS_VALUE_TYPE_TINY_INT:
+        return "tinyint";
+      case CASS_VALUE_TYPE_LIST:
+        return "list";
+      case CASS_VALUE_TYPE_MAP:
+        return "map";
+      case CASS_VALUE_TYPE_SET:
+        return "set";
+      case CASS_VALUE_TYPE_UDT:
+        return "udt";
+      case CASS_VALUE_TYPE_TUPLE:
+        return "tuple";
+      case CASS_VALUE_TYPE_UNKNOWN:
+      default:
+        std::stringstream message;
+        message << "Unsupported Value Type: " << type
+          << " will need to be added";
+        throw Exception(message.str());
+        break;
+     }
+  }
+
+  /**
+   * Overload comparable class for pairing columns
+   */
+  class ColumnsKeyEquality {
+  public:
+    /**
+     * Check to see if the colum names are equal
+     *
+     * @param lhs Left hand side of the equality
+     * @param rhs Right hand side of the equality
+     * @return True if column names are equal; false otherwise
+     */
+    bool operator()(const Pair& lhs, const Pair& rhs) const {
+      return lhs.first.compare(rhs.first) == 0;
+    }
+  };
+};
+
+/**
+ * Priming rows
+ */
+class PrimingRows {
+friend class PrimingRequest;
+public:
+  class Exception : public test::Exception {
+  public:
+    Exception(const std::string& message)
+      : test::Exception(message) {}
+  };
+
+  /**
+   * Builder instantiation of the PrimingColumns object
+   *
+   * @return PrimingColumns instance
+   */
+  static PrimingRows builder() {
+    return PrimingRows();
+  }
+
+  /**
+   * Add a row
+   *
+   * @param columns Columns to add
+   * @param value Value (type|value) for the column
+   * @return PrimingColumns instance
+   */
+  PrimingRows& add_row(PrimingRow columns) {
+    // Make sure the columns can be added to the rows
+    if (!rows_.empty() && rows_.front() != columns) {
+      throw Exception(
+        "Unable to Add Row: Columns are incompatible with previous row(s)");
+    }
+    rows_.push_back(columns);
+    return *this;
+  }
+
+  /**
+   * Checking if the rows are empty (not primed)
+   *
+   * @return True if rows are empty; false otherwise
+   */
+  bool empty() const {
+    return rows_.empty();
+  }
+
+protected:
+  /**
+   * Build the column types for the column used by the rows
+   *
+   * @param writer JSON writer to add the column types to
+   */
+  void build_column_types(
+    rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) {
+    rows_.front().build_column_types(writer);
+  }
+
+  /**
+   * Build the rows
+   *
+   * @param writer JSON writer to add the rows to
+   */
+  void build_rows(rapidjson::PrettyWriter<rapidjson::StringBuffer>* rows) {
+    // Iterate over the rows and add each row to the rows object array
+    rows->Key("rows");
+    rows->StartArray();
+    for (std::vector<PrimingRow>::iterator iterator = rows_.begin();
+      iterator != rows_.end(); ++iterator) {
+      iterator->build_row(rows);
+    }
+    rows->EndArray();
+  }
+
+private:
+  /**
+   * The primed rows
+   */
+  std::vector<PrimingRow> rows_;
+
+  /**
+   * Disallow constructor for builder pattern
+   */
+  PrimingRows() {};
+};
+
+#endif //__PRIMING_ROWS_HPP__

--- a/tests/src/integration/scassandra/scassandra_cluster.cpp
+++ b/tests/src/integration/scassandra/scassandra_cluster.cpp
@@ -1,0 +1,938 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+#include "scassandra_cluster.hpp"
+#include "options.hpp"
+#include "scassandra_rest_client.hpp"
+#include "test_utils.hpp"
+
+#include "scoped_lock.hpp"
+#include "socket.hpp"
+#include "values/uuid.hpp"
+#include "objects/uuid_gen.hpp"
+
+#include <algorithm>
+#include <sstream>
+
+#if UV_VERSION_MAJOR == 0
+# define UV_ERRSTR(status, loop) std::string(uv_strerror(uv_last_error(loop)))
+#else
+# define UV_ERRSTR(status, loop) std::string(uv_strerror(status))
+#endif
+
+#define SCASSANDRA_IP_PREFIX "127.0."
+#define SCASSANDRA_BINARY_PORT 9042
+#define SCASSANDRA_LOG_LEVEL "DEBUG"
+#define SCASSANDRA_REST_PORT_NODE_OFFSET 50000
+#define SCASSANDRA_SPAWN_COMMAND_LENGTH 9
+#define SCASSANDRA_SPAWN_COMMAND_BUFFER 64
+
+#define HTTP_EOL "\r\n"
+#define OUTPUT_BUFFER_SIZE 10240
+#define SCASSANDRA_NAP 100
+#define SCASSANDRA_CONNECTION_RETRIES 600 // Up to 60 seconds for retry based on SCASSANDRA_NAP
+#define SCASSANDRA_PROCESS_RETRIS 100 // Up to 10 seconds for retry based on SCASSANDRA_NAP
+#define MAX_TOKEN static_cast<uint64_t>(INT64_MAX) - 1
+#define DATA_CENTER_PREFIX "dc"
+
+/**
+ * Process information for the SCassandra spawned instance
+ */
+struct Process {
+  /**
+   * Data center for SCassandra process
+   */
+  unsigned int data_center;
+  /**
+   * Node for SCassandra process
+   */
+  unsigned int node;
+  /**
+   * Host ID for the SCassandra process (node information)
+   */
+  std::string host_id;
+  /**
+   * IPv4 address SCassandra process is listening on
+   */
+  std::string listen_address;
+  /**
+   * SCassandra administration port for interacting through REST API
+   */
+  unsigned short admin_port;
+  /**
+   * Flag to check if the SCassandra process is running (spawned)
+   */
+  bool is_running;
+  /**
+   * Loop used during thread execution
+   */
+  uv_loop_t* loop;
+  /**
+   * Process information for spawned SCassandra
+   */
+  uv_process_t process;
+  /**
+   * Thread to utilize for SCassandra process
+   */
+  uv_thread_t thread;
+  /**
+   * Generated command to execute for starting SCassandra process
+   */
+  std::vector<std::string> spawn_command;
+
+  /**
+   * Initialize the process instance; define the application spawn command
+   *
+   * @param data_center Data center the SCassandra instance will be part of
+   * @param node Node in the data center
+   */
+  Process(unsigned int data_center, unsigned int node)
+    : data_center(data_center)
+    , node(node)
+    , is_running(false) {
+    // Create the listen address and admin port for the node
+    std::stringstream listen_address_s;
+    listen_address_s << SCASSANDRA_IP_PREFIX << (data_center - 1) << "." << node;
+    listen_address = listen_address_s.str();
+    admin_port = node + SCASSANDRA_REST_PORT_NODE_OFFSET;
+    test::driver::Uuid uuid = test::driver::UuidGen().generate_random_uuid();
+    host_id = uuid.str();
+
+    // Create the spawn command
+    std::stringstream argument;
+    spawn_command.push_back("java");
+    spawn_command.push_back("-jar");
+    argument << "-Dscassandra.log.level=" << SCASSANDRA_LOG_LEVEL;
+    spawn_command.push_back(argument.str());
+    argument.str("");
+    argument << "-Dscassandra.admin.listen-address=" << listen_address;
+    spawn_command.push_back(argument.str());
+    argument.str("");
+    argument << "-Dscassandra.admin.port=" << admin_port;
+    spawn_command.push_back(argument.str());
+    argument.str("");
+    argument << "-Dscassandra.binary.listen-address=" << listen_address;
+    spawn_command.push_back(argument.str());
+    argument.str("");
+    argument << "-Dscassandra.binary.port=" << SCASSANDRA_BINARY_PORT;
+    spawn_command.push_back(argument.str());
+    argument.str("");
+    spawn_command.push_back(SCASSANDRA_SERVER_JAR);
+  }
+};
+
+// Initialize the mutex and default data center nodes
+uv_mutex_t test::SCassandraCluster::mutex_;
+const unsigned int DEFAULT_NODE[] = { 1 };
+const std::vector<unsigned int> test::SCassandraCluster::DEFAULT_DATA_CENTER_NODES(
+  DEFAULT_NODE, DEFAULT_NODE + sizeof(DEFAULT_NODE) / sizeof(DEFAULT_NODE[0]));
+
+test::SCassandraCluster::SCassandraCluster() {
+  // Initialize the mutex
+  uv_mutex_init(&mutex_);
+
+  // Determine if SCassandra file exists
+  if (!test::Utils::file_exists(SCASSANDRA_SERVER_JAR)) {
+    std::stringstream message;
+    message << "Unable to find SCassandra JAR file ["
+      << SCASSANDRA_SERVER_JAR << "]";
+    throw Exception(message.str());
+  }
+
+  // Determine the release version (for priming nodes)
+  if (Options::is_dse()) {
+    CCM::DseVersion dse_version(Options::server_version());
+    CCM::CassVersion cass_version = dse_version.get_cass_version();
+    if (cass_version == "0.0.0") {
+      throw Exception("Unable to determine Cassandra version from DSE version");
+    }
+    release_version_ = test::Utils::replace_all(cass_version.to_string(), "-",
+      ".");
+  }
+
+  // Generate the schema version (for priming nodes)
+  test::driver::Uuid uuid = test::driver::UuidGen().generate_random_uuid();
+  schema_version_ = uuid.str();
+}
+
+test::SCassandraCluster::~SCassandraCluster() {
+  destroy_cluster();
+}
+
+std::string test::SCassandraCluster::cluster_contact_points(bool is_all /*= true*/) {
+  std::stringstream contact_points;
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    // Determine if all the nodes are being returned or just the available nodes
+    Process process = iterator->second;
+    if (is_all || is_node_up(iterator->first)) {
+      if (!contact_points.str().empty()) {
+        contact_points << ",";
+      }
+      contact_points << get_ip_prefix(process.data_center) << process.node;
+    }
+  }
+  return contact_points.str();
+}
+
+void test::SCassandraCluster::create_cluster(
+  std::vector<unsigned int> data_center_nodes /*= DEFAULT_DATA_CENTER_NODES*/) {
+  create_processes(data_center_nodes);
+
+  // Create the peers mapping for easy lookup
+  for (ProcessMap::iterator outer = processes_.begin();
+    outer != processes_.end(); ++outer) {
+    unsigned int node = outer->first;
+    std::vector<Process*> processes;
+    for (ProcessMap::iterator inner = processes_.begin();
+      inner != processes_.end(); ++inner) {
+      if (inner->first != node) {
+        processes.push_back(&inner->second);
+      }
+    }
+    peers_.insert(PeersPair(node, processes));
+  }
+}
+
+void test::SCassandraCluster::create_cluster(unsigned int data_center_one_nodes,
+  unsigned int data_center_two_nodes /*= 0*/) {
+  std::vector<unsigned int> data_center_nodes;
+  if (data_center_one_nodes > 0) {
+    data_center_nodes.push_back(data_center_one_nodes);
+  }
+  if (data_center_two_nodes > 0) {
+    data_center_nodes.push_back(data_center_two_nodes);
+  }
+  create_cluster(data_center_nodes);
+}
+
+std::string test::SCassandraCluster::get_ip_address(unsigned int node) const {
+  ProcessMap::const_iterator iterator = processes_.find(node);
+  if (iterator == processes_.end()) {
+    std::stringstream message;
+    message << "Unable to Locate Node: " << node << " is invalid";
+    throw Exception(message.str());
+  }
+  return iterator->second.listen_address;
+}
+
+std::string test::SCassandraCluster::get_ip_prefix(
+  unsigned int data_center /*= 1*/) const {
+  if (data_center == 0) {
+    throw Exception("Invalid Data Center: Must be greater than zero");
+  }
+
+  std::stringstream ip_prefix;
+  ip_prefix << SCASSANDRA_IP_PREFIX << (data_center - 1) << ".";
+  return ip_prefix.str();
+}
+
+bool test::SCassandraCluster::is_node_down(unsigned int node) {
+  // Attempt to connect to the binary port on the node
+  unsigned int number_of_retries = 0;
+  while (number_of_retries++ < SCASSANDRA_CONNECTION_RETRIES) {
+    if (!is_node_available(node)) {
+      return true;
+    } else {
+      LOG("Connected to Node " << node
+        << " in Cluster: Rechecking node down status ["
+        << number_of_retries << "]");
+      test::Utils::msleep(SCASSANDRA_NAP);
+    }
+  }
+
+  // Connection can still be established on node
+  return false;
+}
+
+bool test::SCassandraCluster::is_node_up(unsigned int node) {
+  // Attempt to connect to the binary port on the node
+  unsigned int number_of_retries = 0;
+  while (number_of_retries++ < SCASSANDRA_CONNECTION_RETRIES) {
+    if (is_node_available(node)) {
+      return true;
+    } else {
+      LOG("Unable to Connect to Node " << node
+        << " in Cluster: Rechecking node up status ["
+        << number_of_retries << "]");
+      test::Utils::msleep(SCASSANDRA_NAP);
+    }
+  }
+
+  // Connection cannot be established on node
+  return false;
+}
+
+bool test::SCassandraCluster::destroy_cluster() {
+  // Clear the processes and peers if the cluster was stopped
+  if (stop_cluster()) {
+    peers_.clear();
+    processes_.clear();
+    return true;
+  }
+  return false;
+}
+
+bool test::SCassandraCluster::start_cluster() {
+  // Start each SCassandra node/process
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    // Start the node but do not wait for the node to be up
+    start_node(iterator->first, false);
+  }
+
+  // Wait for each SCassandra node/process to be running
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    while (!iterator->second.is_running) {
+      test::Utils::msleep(SCASSANDRA_NAP);
+    }
+  }
+
+  // Determine if the cluster is ready
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    try {
+      if (!is_node_up(iterator->first)) {
+        return false;
+      }
+    } catch (Exception e) {
+      LOG_ERROR(e.what());
+      return false;
+    }
+  }
+  return true;
+}
+
+bool test::SCassandraCluster::stop_cluster() {
+  // Stop each SCassandra node/process
+  for (ProcessMap::iterator iterator = processes_.begin();
+    // Stop the node but do not wait for the node to be down
+    iterator != processes_.end(); ++iterator) {
+    stop_node(iterator->first, false);
+  }
+
+  // Wait for each SCassandra node/process to be finished
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    while (iterator->second.is_running) {
+      test::Utils::msleep(SCASSANDRA_NAP);
+    }
+  }
+
+  // Determine if the cluster is down
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    try {
+      if (!is_node_down(iterator->first)) {
+        return false;
+      }
+    } catch (Exception e) {
+      LOG_ERROR(e.what());
+      return false;
+    }
+  }
+
+  // Indicate the cluster was stopped)
+  return true;
+}
+
+bool test::SCassandraCluster::start_node(unsigned int node,
+  bool wait_for_up /*= true*/) {
+  ProcessMap::iterator iterator = processes_.find(node);
+
+  // Make sure node is valid
+  if (iterator == processes_.end()) {
+    return false;
+  }
+
+  // Ensure the process is not already running
+  Process* process = &iterator->second;
+  if (!process->is_running) {
+    // Create SCassandra process (threaded)
+    uv_thread_create(&process->thread, handle_thread_create, process);
+  }
+
+  // Wait for the node to become available
+  if (wait_for_up) {
+    return is_node_up(node);
+  }
+  return true;
+}
+
+bool test::SCassandraCluster::stop_node(unsigned int node,
+  bool wait_for_down /*= true*/) {
+  ProcessMap::iterator iterator = processes_.find(node);
+
+  // Make sure node is valid
+  if (iterator == processes_.end()) {
+    return false;
+  }
+
+  // Ensure the process is running
+  Process process = iterator->second;
+  if (process.is_running) {
+    // TODO: Add exceptions if the process can't be killed
+    int error_code = uv_process_kill(&process.process, SIGTERM);
+    if (error_code == 0) {
+      uv_close(reinterpret_cast<uv_handle_t*>(&process.process), NULL);
+      error_code = uv_thread_join(&process.thread);
+      if (error_code != 0) {
+        LOG_ERROR(UV_ERRSTR(error_code, process.loop));
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  // Wait for the node to become unavailable
+  if (wait_for_down) {
+    return is_node_down(node);
+  }
+  return true;
+}
+
+std::vector<unsigned int> test::SCassandraCluster::nodes(
+  bool is_available /*= true*/) {
+  std::vector<unsigned int> nodes;
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    if (!is_available || iterator->second.is_running) {
+      nodes.push_back(iterator->first);
+    }
+  }
+  return nodes;
+}
+
+void test::SCassandraCluster::prime_system_tables() {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    if (iterator->second.is_running) {
+      prime_system_tables(iterator->first);
+    }
+  }
+}
+
+void test::SCassandraCluster::reset_cluster() {
+  // Clear all activity
+  remove_recorded_connections();
+  remove_recorded_executed_batch_statements();
+  remove_recorded_executed_prepared_statements();
+  remove_recorded_executed_queries();
+  remove_recorded_prepared_statements();
+
+  // Clear all primed queries
+  remove_primed_queries();
+}
+
+void test::SCassandraCluster::remove_recorded_connections(unsigned int node) {
+  send_delete(node, "connection");
+}
+
+void test::SCassandraCluster::remove_recorded_connections() {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    remove_recorded_connections(iterator->first);
+  }
+}
+
+void test::SCassandraCluster::remove_recorded_executed_batch_statements(
+  unsigned int node) {
+  send_delete(node, "batch-execution");
+}
+
+void test::SCassandraCluster::remove_recorded_executed_batch_statements() {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    remove_recorded_executed_batch_statements(iterator->first);
+  }
+}
+
+void test::SCassandraCluster::remove_recorded_executed_prepared_statements(
+  unsigned int node) {
+  send_delete(node, "prepared-statement-execution");
+}
+
+void test::SCassandraCluster::remove_recorded_executed_prepared_statements() {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    remove_recorded_executed_prepared_statements(iterator->first);
+  }
+}
+
+void test::SCassandraCluster::remove_recorded_executed_queries(
+  unsigned int node) {
+  send_delete(node, "query");
+}
+
+void test::SCassandraCluster::remove_recorded_executed_queries() {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    remove_recorded_executed_queries(iterator->first);
+  }
+}
+
+void test::SCassandraCluster::remove_recorded_prepared_statements(
+  unsigned int node) {
+  send_delete(node, "prepared-statement-preparation");
+}
+
+void test::SCassandraCluster::remove_recorded_prepared_statements() {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    remove_recorded_prepared_statements(iterator->first);
+  }
+}
+
+std::vector<std::string> test::SCassandraCluster::active_connections(
+  unsigned int node) {
+  std::string json_response = send_get(node, "current/connections");
+  rapidjson::Document document;
+  document.Parse(json_response.c_str());
+
+  // Find all the connections members and create the host:port value
+  std::vector<std::string> connections;
+  if (document.HasMember("connections")) {
+    const rapidjson::Value& active_connections = document["connections"];
+    if (active_connections.IsArray()) {
+      for (rapidjson::Value::ConstValueIterator iterator = active_connections.Begin();
+        iterator != active_connections.End(); ++iterator) {
+        if (iterator->IsObject()) {
+          const rapidjson::Value& active_connection = *iterator;
+          std::stringstream connection;
+          connection << active_connection["host"].GetString()
+            << ":" << active_connection["port"].GetInt();
+          connections.push_back(connection.str());
+        } else {
+          throw Exception("Connections JSON array does not contain any objects");
+        }
+      }
+    } else {
+      throw Exception("Connections is not a valid JSON array");
+    }
+  } else {
+    LOG_DEBUG("No active connections returned from SCassandra server");
+  }
+  return connections;
+}
+
+test::SCassandraCluster::ActiveConnectionsMap test::SCassandraCluster::active_connections() {
+  ActiveConnectionsMap connections;
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    connections.insert(ActiveConnectionsPair(iterator->first,
+      active_connections(iterator->first)));
+  }
+  return connections;
+}
+
+void test::SCassandraCluster::prime_query(PrimingRequest request) {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    prime_query(iterator->first, request);
+  }
+}
+
+void test::SCassandraCluster::prime_query(unsigned int node,
+  PrimingRequest request) {
+  send_post(node, "prime-query-single", request.json());
+}
+
+void test::SCassandraCluster::remove_primed_queries() {
+  for (ProcessMap::iterator iterator = processes_.begin();
+    iterator != processes_.end(); ++iterator) {
+    remove_primed_queries(iterator->first);
+  }
+}
+
+void test::SCassandraCluster::remove_primed_queries(unsigned int node) {
+  send_delete(node, "prime-query-single");
+}
+
+#if UV_VERSION_MAJOR == 0
+void test::SCassandraCluster::handle_exit(uv_process_t* process, int error_code,
+  int term_signal) {
+#else
+void test::SCassandraCluster::handle_exit(uv_process_t* process,
+  int64_t error_code, int term_signal) {
+#endif
+  cass::ScopedMutex lock(&mutex_);
+  LOG("Process " << process->pid << " Terminated: " << error_code);
+  uv_close(reinterpret_cast<uv_handle_t*>(process), NULL);
+}
+
+#if UV_VERSION_MAJOR == 0
+uv_buf_t test::SCassandraCluster::handle_allocation(uv_handle_t* handle,
+  size_t suggested_size) {
+  cass::ScopedMutex lock(&mutex_);
+  return uv_buf_init(new char[suggested_size], suggested_size);
+#else
+void test::SCassandraCluster::handle_allocation(uv_handle_t* handle,
+  size_t suggested_size, uv_buf_t* buffer) {
+  cass::ScopedMutex lock(&mutex_);
+  buffer->base = new char[OUTPUT_BUFFER_SIZE];
+  buffer->len = OUTPUT_BUFFER_SIZE;
+#endif
+}
+
+void test::SCassandraCluster::handle_thread_create(void* arg) {
+  Process* process = static_cast<Process*>(arg);
+
+  // Initialize the loop and process arguments
+#if UV_VERSION_MAJOR == 0
+  uv_loop_t* loop = uv_loop_new();
+  process->loop = loop;
+#else
+  uv_loop_t loop;
+  if(uv_loop_init(&loop) != 0) {
+    std::stringstream message;
+    message << "Unable to Create SCassandra Node " << process->node
+      << " for Data Center " << process->data_center
+      << ": libuv loop initialization failed";
+    throw Exception(message.str());
+  };
+  process->loop = &loop;
+#endif
+  uv_process_options_t options;
+  memset(&options, 0, sizeof(uv_process_options_t));
+
+  // Create the options for reading information from the spawn pipes
+  uv_pipe_t standard_output;
+  uv_pipe_t error_output;
+#if UV_VERSION_MAJOR == 0
+  uv_pipe_init(loop, &standard_output, 0);
+  uv_pipe_init(loop, &error_output, 0);
+#else
+  uv_pipe_init(&loop, &standard_output, 0);
+  uv_pipe_init(&loop, &error_output, 0);
+#endif
+  uv_stdio_container_t stdio[3];
+  options.stdio_count = 3;
+  options.stdio = stdio;
+  options.stdio[0].flags = UV_IGNORE;
+  options.stdio[1].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
+  options.stdio[1].data.stream = (uv_stream_t*) &standard_output;
+  options.stdio[2].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
+  options.stdio[2].data.stream = (uv_stream_t*) &error_output;
+
+  // Generate the spawn command for use with uv_spawn
+  const char* spawn_command[SCASSANDRA_SPAWN_COMMAND_LENGTH];
+  size_t index = 0;
+  for (std::vector<std::string>::iterator iterator = process->spawn_command.begin();
+  iterator != process->spawn_command.end(); ++iterator) {
+    spawn_command[index++] = iterator->data();
+  }
+  spawn_command[index] = NULL;
+
+  // Create the options for the process
+  options.args = const_cast<char**>(spawn_command);
+  options.exit_cb = handle_exit;
+  options.file = spawn_command[0];
+
+  // Start the process
+#if UV_VERSION_MAJOR == 0
+  int error_code = uv_spawn(loop, &process->process, options);
+#else
+  int error_code = uv_spawn(&loop, &process->process, &options);
+#endif
+  if (error_code == 0) {
+    LOG("Launched " << spawn_command[0] << " with ID "
+      << process->process.pid);
+
+    // Start the output thread loops
+    uv_read_start(reinterpret_cast<uv_stream_t*>(&standard_output),
+      handle_allocation, handle_read);
+    uv_read_start(reinterpret_cast<uv_stream_t*>(&error_output),
+      handle_allocation, handle_read);
+
+    // Start the process loop
+    process->is_running = true;
+#if UV_VERSION_MAJOR == 0
+    uv_run(loop, UV_RUN_DEFAULT);
+    uv_loop_delete(loop);
+#else
+    uv_run(&loop, UV_RUN_DEFAULT);
+    uv_loop_close(&loop);
+#endif
+    process->is_running = false;
+  } else {
+    LOG_ERROR(UV_ERRSTR(error_code, loop));
+  }
+}
+
+#if UV_VERSION_MAJOR == 0
+void test::SCassandraCluster::handle_read(uv_stream_t* stream,
+  ssize_t buffer_length, uv_buf_t buffer) {
+#else
+void test::SCassandraCluster::handle_read(uv_stream_t* stream,
+  ssize_t buffer_length, const uv_buf_t* buffer) {
+#endif
+  cass::ScopedMutex lock(&mutex_);
+  if (buffer_length > 0) {
+    // Process the buffer and log it
+#if UV_VERSION_MAJOR == 0
+    std::string message(buffer.base, buffer_length);
+#else
+    std::string message(buffer->base, buffer_length);
+#endif
+    LOG(Utils::trim(message));
+  } else if (buffer_length < 0) {
+#if UV_VERSION_MAJOR == 0
+    uv_err_t error = uv_last_error(stream->loop);
+    if (error.code == UV_EOF) // uv_close if UV_EOF
+#endif
+    uv_close(reinterpret_cast<uv_handle_t*>(stream), NULL);
+  }
+
+  // Clean up the memory allocated
+#if UV_VERSION_MAJOR == 0
+  delete[] buffer.base;
+#else
+  delete[] buffer->base;
+#endif
+}
+
+void test::SCassandraCluster::create_processes(std::vector<unsigned int> nodes) {
+  // Create the process for each data center and the nodes within
+  unsigned int data_center = 1;
+  unsigned int node = 1;
+  for (std::vector<unsigned int>::iterator iterator = nodes.begin();
+    iterator != nodes.end(); ++iterator) {
+    for (unsigned int n = 1; n <= *iterator; ++n) {
+      processes_.insert(ProcessPair(node++, Process(data_center, n)));
+    }
+    ++data_center;
+  }
+}
+
+void test::SCassandraCluster::send_delete(unsigned int node,
+  const std::string& endpoint) {
+  Response response = send_request(Request::HTTP_METHOD_DELETE, node, endpoint);
+  if (response.status_code != 200) {
+    std::stringstream message;
+    message << "DELETE Operation " << endpoint
+      << "did not Complete Successfully: " << response.status_code;
+    throw Exception(message.str());
+  }
+}
+
+const std::string test::SCassandraCluster::send_get(unsigned int node,
+  const std::string& endpoint) {
+  Response response = send_request(Request::HTTP_METHOD_GET, node, endpoint);
+  if (response.status_code != 200) {
+    std::stringstream message;
+    message << "GET Operation " << endpoint
+      << "did not Complete Successfully: " << response.status_code;
+    throw Exception(message.str());
+  }
+  return response.message;
+}
+
+void test::SCassandraCluster::send_post(unsigned int node,
+  const std::string& endpoint, const std::string& content) {
+  Response response = send_request(Request::HTTP_METHOD_POST, node, endpoint,
+    content);
+  if (response.status_code != 200) {
+    std::stringstream message;
+    message << "POST Operation " << endpoint
+      << "did not Complete Successfully: " << response.status_code;
+    throw Exception(message.str());
+  }
+}
+
+Response test::SCassandraCluster::send_request(Request::Method method,
+  unsigned int node, const std::string& endpoint,
+  const std::string& content /*= ""*/) {
+  // Determine if the node is valid and is the process is running
+  ProcessMap::const_iterator iterator = processes_.find(node);
+  if (iterator == processes_.end()) {
+    std::stringstream message;
+    message << "Unable to Find Node: Node " << node << " is not a valid node";
+    throw Exception(message.str());
+  }
+
+  // Create and send the request to the REST server
+  Request request;
+  request.method = method;
+  request.address = iterator->second.listen_address;
+  request.port = iterator->second.admin_port;
+  request.endpoint = endpoint;
+  if (method == Request::HTTP_METHOD_POST && !content.empty()) {
+    request.content = content;
+  }
+  return SCassandraRestClient::send_request(request);
+}
+
+bool test::SCassandraCluster::is_node_available(unsigned int node) {
+  // Determine if the node is valid and is the process is running
+  ProcessMap::iterator iterator = processes_.find(node);
+  if (iterator == processes_.end()) {
+    std::stringstream message;
+    message << "Unable to Check Availability of Node: Node " << node
+      << " is not a valid node";
+    throw test::Exception(message.str());
+  }
+
+  // Determine if the node is available
+  std::string ip_address = iterator->second.listen_address;
+  unsigned short port = iterator->second.admin_port;
+  return is_node_available(ip_address, port);
+}
+
+bool test::SCassandraCluster::is_node_available(const std::string& ip_address,
+  unsigned short port) {
+  Socket socket;
+  try {
+    socket.establish_connection(ip_address, port);
+    return true;
+  } catch (...) {
+    ; // No-op
+  }
+
+  // Unable to establish connection to node
+  return false;
+}
+
+std::vector<std::string> test::SCassandraCluster::generate_token_ranges(
+  unsigned int data_center, unsigned int nodes) {
+  // Create and sort the token ranges
+  int offset = (data_center - 1) * 100;
+  std::vector<int64_t> token_ranges;
+  for(unsigned int n = 0; n < nodes; ++n) {
+    int64_t token_range = static_cast<uint64_t>(((UINT64_MAX / nodes) * n)) -
+      MAX_TOKEN;
+    token_ranges.push_back(token_range + offset);
+  }
+  std::sort(token_ranges.begin(), token_ranges.end());
+
+  // Convert the token ranges to a vector of strings
+  std::vector<std::string> token_ranges_s;
+  for(std::vector<int64_t>::iterator iterator = token_ranges.begin();
+    iterator != token_ranges.end(); ++iterator) {
+    std::stringstream token_range_stream;
+    token_range_stream << *iterator;
+    token_ranges_s.push_back(token_range_stream.str());
+  }
+  return token_ranges_s;
+}
+
+void test::SCassandraCluster::prime_system_tables(unsigned int node) {
+  // Determine if the node is valid and is the process is running
+  ProcessMap::iterator process_iterator = processes_.find(node);
+  if (process_iterator == processes_.end()) {
+    std::stringstream message;
+    message << "Unable to Prime System Tables: Node " << node
+      << " is not a valid node";
+    throw test::Exception(message.str());
+  }
+  unsigned int data_center = process_iterator->second.data_center;
+  unsigned int data_center_node = process_iterator->second.node;
+  std::string host_id = process_iterator->second.host_id;
+  std::string node_address = process_iterator->second.listen_address;
+
+  // Determine if the peers are valid (this should never error)
+  PeersMap::iterator peers_iterator = peers_.find(node);
+  if (peers_iterator == peers_.end()) {
+    std::stringstream message;
+    message << "Unable to Prime System Tables: Node " << node
+      << " did not define peers (this should never happen)";
+    throw test::Exception(message.str());
+  }
+  std::vector<Process*> peers = peers_iterator->second;
+  unsigned int nodes = peers.size() + 1;
+
+  // Prime the system.local and system.peers table
+  std::stringstream data_center_name;
+    data_center_name << DATA_CENTER_PREFIX << data_center;
+  std::vector<std::string> token_ranges = generate_token_ranges(data_center,
+    nodes);
+  std::string token = token_ranges.at(data_center_node - 1);
+
+  // Prime the system.local table
+  PrimingRow row = PrimingRow::builder()
+    .add_column("bootstrapped", CASS_VALUE_TYPE_VARCHAR, "COMPLETED")
+    .add_column("broadcast_address", CASS_VALUE_TYPE_INET, node_address)
+    .add_column("cluster_name", CASS_VALUE_TYPE_VARCHAR, "SCassandra")
+    .add_column("data_center", CASS_VALUE_TYPE_VARCHAR,
+      data_center_name.str())
+    .add_column("host_id", CASS_VALUE_TYPE_UUID, host_id)
+    .add_column("key", CASS_VALUE_TYPE_VARCHAR, "local")
+    .add_column("listen_address", CASS_VALUE_TYPE_INET, node_address)
+    .add_column("partitioner", CASS_VALUE_TYPE_VARCHAR,
+      "org.apache.cassandra.dht.Murmur3Partitioner")
+    .add_column("rack", CASS_VALUE_TYPE_VARCHAR, "r1") //TODO: Allow for multiple racks
+    .add_column("release_version", CASS_VALUE_TYPE_VARCHAR, release_version_)
+    .add_column("rpc_address", CASS_VALUE_TYPE_INET, node_address)
+    .add_column("schema_version", CASS_VALUE_TYPE_UUID, schema_version_)
+    .add_column("tokens", "set<text>", "[" + token + "]");
+  if (Options::is_dse()) {
+    row.add_column("dse_version", CASS_VALUE_TYPE_VARCHAR,
+        Options::server_version().to_string())
+      .add_column("graph", CASS_VALUE_TYPE_BOOLEAN, "false")
+      .add_column("workload", CASS_VALUE_TYPE_VARCHAR, "Cassandra");
+  }
+  PrimingRequest system_local = PrimingRequest::builder()
+    .with_query_pattern("SELECT .* FROM system.local WHERE key='local'")
+    .with_consistency(CASS_CONSISTENCY_ANY)
+    .with_consistency(CASS_CONSISTENCY_ONE)
+    .with_consistency(CASS_CONSISTENCY_TWO)
+    .with_consistency(CASS_CONSISTENCY_THREE)
+    .with_consistency(CASS_CONSISTENCY_QUORUM)
+    .with_consistency(CASS_CONSISTENCY_ALL)
+    .with_consistency(CASS_CONSISTENCY_LOCAL_QUORUM)
+    .with_consistency(CASS_CONSISTENCY_EACH_QUORUM)
+    .with_consistency(CASS_CONSISTENCY_SERIAL)
+    .with_consistency(CASS_CONSISTENCY_LOCAL_SERIAL)
+    .with_consistency(CASS_CONSISTENCY_LOCAL_ONE)
+    .with_rows(PrimingRows::builder().add_row(row));
+  prime_query(node, system_local);
+
+  // Generate the rows for the system.peers table
+  PrimingRows peers_rows = PrimingRows::builder();
+  for (std::vector<Process*>::iterator iterator = peers.begin();
+    iterator != peers.end(); ++iterator) {
+    Process* process = *iterator;
+    data_center_node = process->node;
+    host_id = process->host_id;
+    node_address = process->listen_address;
+    token = token_ranges.at(data_center_node - 1);
+
+    PrimingRow row = PrimingRow::builder()
+      .add_column("data_center", CASS_VALUE_TYPE_VARCHAR, data_center_name.str())
+      .add_column("host_id", CASS_VALUE_TYPE_UUID, host_id)
+      .add_column("peer", CASS_VALUE_TYPE_INET, node_address)
+      .add_column("rack", CASS_VALUE_TYPE_VARCHAR, "rack1") //TODO: Allow for multiple racks
+      .add_column("release_version", CASS_VALUE_TYPE_VARCHAR, release_version_)
+      .add_column("rpc_address", CASS_VALUE_TYPE_INET, node_address)
+      .add_column("schema_version", CASS_VALUE_TYPE_UUID, schema_version_)
+      .add_column("tokens", "set<text>", "[" + token + "]");
+    if (Options::is_dse()) {
+      row.add_column("dse_version", CASS_VALUE_TYPE_VARCHAR,
+          Options::server_version().to_string())
+        .add_column("graph", CASS_VALUE_TYPE_BOOLEAN, "false")
+        .add_column("workload", CASS_VALUE_TYPE_VARCHAR, "Cassandra");
+    }
+    peers_rows.add_row(row);
+  }
+
+  // Prime the system.peers table
+  PrimingRequest system_peers = PrimingRequest::builder()
+    .with_query_pattern("SELECT .* FROM system.peers")
+    .with_consistency(CASS_CONSISTENCY_ANY)
+    .with_consistency(CASS_CONSISTENCY_ONE)
+    .with_consistency(CASS_CONSISTENCY_TWO)
+    .with_consistency(CASS_CONSISTENCY_THREE)
+    .with_consistency(CASS_CONSISTENCY_QUORUM)
+    .with_consistency(CASS_CONSISTENCY_ALL)
+    .with_consistency(CASS_CONSISTENCY_LOCAL_QUORUM)
+    .with_consistency(CASS_CONSISTENCY_EACH_QUORUM)
+    .with_consistency(CASS_CONSISTENCY_SERIAL)
+    .with_consistency(CASS_CONSISTENCY_LOCAL_SERIAL)
+    .with_consistency(CASS_CONSISTENCY_LOCAL_ONE)
+    .with_rows(peers_rows);
+  prime_query(node, system_peers);
+}

--- a/tests/src/integration/scassandra/scassandra_cluster.hpp
+++ b/tests/src/integration/scassandra/scassandra_cluster.hpp
@@ -1,0 +1,491 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __TEST_SCASSANDRA_CLUSTER_HPP__
+#define __TEST_SCASSANDRA_CLUSTER_HPP__
+
+// Make sure SCassandra server is available during compile time
+#ifdef DSE_USE_STANDALONE_SCASSANDRA_SERVER
+#include "exception.hpp"
+#include "priming_requests.hpp"
+#include "shared_ptr.hpp"
+#include "scassandra_rest_client.hpp"
+
+#ifdef _CRT_SECURE_NO_WARNINGS
+# undef _CRT_SECURE_NO_WARNINGS
+#endif
+#include <rapidjson/document.h>
+#include <uv.h>
+
+#include <cstdio>
+#include <map>
+#include <string>
+#include <string.h>
+
+// Forward declare for process struct in source
+struct Process;
+
+namespace test {
+
+/**
+ * SCassandra cluster for easily creating SCassandra instances/nodes
+ */
+class SCassandraCluster {
+public:
+  class Exception : public test::Exception {
+  public:
+    Exception(const std::string& message)
+      : test::Exception(message) {}
+  };
+  typedef std::map<unsigned int, std::vector<std::string> > ActiveConnectionsMap;
+  typedef std::pair<unsigned int, std::vector<std::string> > ActiveConnectionsPair;
+  /**
+   * Default DSE workload to apply (Cassandra)
+   */
+  static const std::vector<unsigned int> DEFAULT_DATA_CENTER_NODES;
+
+  /**
+   * Initialize the SCassandra cluster
+   *
+   * @throws SCassandraCluster::Exception If SCassandra JAR is unavailable
+   */
+  SCassandraCluster();
+
+  /**
+   * Terminate all SCassandra clusters and perform any additional cleanup
+   * operations
+   */
+  ~SCassandraCluster();
+
+  /**
+   * Get a comma separated list of IPv4 addresses for nodes in the active
+   * SCassandra cluster
+   *
+   * @param is_all True if all node IPv4 addresses should be returned; false
+   *               if only the `UP` nodes (default: true)
+   * @return Comma separated list of IPv4 addresses
+   */
+  std::string cluster_contact_points(bool is_all = true);
+
+  /**
+   * Create the SCassandra cluster; data centers and nodes within each data
+   * center
+   *
+   * @param data_center_nodes Data center(s) to create in the SCassandra cluster
+   *                          (default: 1 data center with 1 node)
+   */
+  void create_cluster(
+    std::vector<unsigned int> data_center_nodes = DEFAULT_DATA_CENTER_NODES);
+
+  /**
+   * Create the SCassandra cluster; number of nodes in data center 1 and 2
+   *
+   * @param data_center_one_nodes Number of nodes in data center 1
+   * @param data_center_two_nodes Number of nodes in data center 2 (default: 0)
+   */
+  void create_cluster(unsigned int data_center_one_nodes,
+    unsigned int data_center_two_nodes = 0);
+
+  /**
+   * Get the IPv4 address being utilized for a given node
+   *
+   * @param node Node to get IPv4 address
+   * @return IPv4 address being used by the node
+   * @throws SCassandraCluster::Exception If node is not valid
+   */
+  std::string get_ip_address(unsigned int node) const;
+
+  /**
+   * Get the IPv4 address prefix being utilized for the SCassandra cluster for a
+   * given data center
+   *
+   * @param data_center Data center to get IPv4 address prefix (default: 1)
+   * @return IPv4 address prefix used
+   * @throws SCassandraCluster::Exception If data center is not valid
+   */
+  std::string get_ip_prefix(unsigned int data_center = 1) const;
+
+  /**
+   * Stop (terminate the SCassandra process) and destroy SCassandra cluster
+   * (requires cluster to be re-created; processes and peers are cleared)
+   *
+   * @return True is cluster is down; false otherwise
+   */
+  bool destroy_cluster();
+
+  /**
+   * Start the SCassandra cluster
+   *
+   * @return True is cluster is up; false otherwise
+   */
+  bool start_cluster();
+
+  /**
+   * Stop the SCassandra cluster (terminate the SCassandra process)
+   *
+   * @return True is cluster is down; false otherwise
+   */
+  bool stop_cluster();
+
+  /**
+   * Start a node on the SCassandra cluster
+   *
+   * NOTE: If node is not valid false is returned
+   *
+   * @param node Node to start
+   * @param wait_for_up True if waiting for node to be up; false otherwise
+   * @return True if node was started (and is up if wait_for_up is true); false
+   *         otherwise
+   */
+  bool start_node(unsigned int node, bool wait_for_up = true);
+
+  /**
+   * Stop a node on the SCassandra cluster
+   *
+   * NOTE: If node is not valid false is returned
+   *
+   * @param node Node to stop
+   * @param wait_for_down True if waiting for node to be down; false otherwise
+   * @return True if node was stopped (and is dpwn if wait_for_down is true);
+   *         false otherwise
+   */
+  bool stop_node(unsigned int node, bool wait_for_down = true);
+
+  /**
+   * Check to see if a node is no longer accepting connections
+   *
+   * NOTE: This method may check the status of the node multiple times
+   *
+   * @param node Node to check 'DOWN' status
+   * @return True if node is no longer accepting connections; false otherwise
+   * @throws Exception if node is not valid
+   */
+  bool is_node_down(unsigned int node);
+
+  /**
+   * Check to see if a node is ready to accept connections
+   *
+   * NOTE: This method may check the status of the node multiple times
+   *
+   * @param node Node to check 'UP' status
+   * @return True if node is ready to accept connections; false otherwise
+   * @throws Exception if node is not valid or process is not running
+   */
+  bool is_node_up(unsigned int node);
+
+  /**
+   * Get the nodes in the cluster
+   *
+   * @param is_available True if only active/available nodes should be returned;
+   *                     false otherwise (DEFAULT: true)
+   * @return List of nodes in the cluster; available nodes only if
+   *         `is_available` is true
+   */
+  std::vector<unsigned int> nodes(bool is_available = true);
+
+  /**
+   * Prime the system tables (local and peers) for all the active nodes in the
+   * SCassandra cluster
+   */
+  void prime_system_tables();
+
+  /**
+   * Reset the cluster; remove all activity from the cluster including primed
+   * queries.
+   */
+  void reset_cluster();
+
+  ///////////////////////////// ACTIVITY ////////////////////////////////////
+
+  /**
+   * Remove all the recorded connections on a given node in the SCassandra
+   * cluster
+   *
+   * @param node Node to remove recorded connections from
+   */
+  void remove_recorded_connections(unsigned int node);
+
+  /**
+   * Remove all the recorded connections in the SCassandra cluster
+   */
+  void remove_recorded_connections();
+
+  /**
+   * Remove all the recorded executed batch statements on a given node in the
+   * SCassandra cluster
+   *
+   * @param node Node to remove recorded executed batch statements from
+   */
+  void remove_recorded_executed_batch_statements(unsigned int node);
+
+  /**
+   * Remove all the recorded executed batch statements in the SCassandra cluster
+   */
+  void remove_recorded_executed_batch_statements();
+
+  /**
+   * Remove all the recorded executed prepared statements on a given node in the
+   * SCassandra cluster
+   *
+   * @param node Node to remove recorded execute prepared statements from
+   */
+  void remove_recorded_executed_prepared_statements(unsigned int node);
+
+  /**
+   * Remove all the recorded executed prepared statements in the SCassandra
+   * cluster
+   */
+  void remove_recorded_executed_prepared_statements();
+
+  /**
+   * Remove all the recorded executed queries on a given node in the SCassandra
+   * cluster
+   *
+   * @param node Node to remove recorded executed queries from
+   */
+  void remove_recorded_executed_queries(unsigned int node);
+
+  /**
+   * Remove all the recorded executed queries in the SCassandra cluster
+   */
+  void remove_recorded_executed_queries();
+
+  /**
+   * Remove all the recorded prepared statements on a given node in the
+   * SCassandra cluster
+   *
+   * @param node Node to remove recorded prepared statements from
+   */
+  void remove_recorded_prepared_statements(unsigned int node);
+
+  /**
+   * Remove all the recorded prepared statements in the SCassandra cluster
+   */
+  void remove_recorded_prepared_statements();
+
+  ///////////////////////// CURRENT ENDPOINT ////////////////////////////////
+
+  /**
+   * Get the active (current) connections on a given node in the SCassandra
+   * cluster
+   *
+   * @param node Node to remove recorded prepared statements from
+   * @return List of connections on the node
+   * @throws Exception if JSON response is invalid
+   */
+  std::vector<std::string> active_connections(unsigned int node);
+
+  /**
+   * Get the active (current) connections in the SCassandra cluster
+   *
+   * @return Map of connections on each node
+   * @throws Exception if JSON response is invalid
+   */
+  ActiveConnectionsMap active_connections();
+
+  ///////////////////////// PRIMING QUERIES /////////////////////////////////
+
+  /**
+   * Prime the queries on SCassandra cluster using the REST API
+   *
+   * @param request Request to prime
+   */
+  void prime_query(PrimingRequest request);
+
+  /**
+   * Prime the queries on SCassandra using the REST API
+   *
+   * @param node Node to prime the query on
+   * @param request Request to prime
+   */
+  void prime_query(unsigned int node, PrimingRequest request);
+
+  /**
+   * Remove all the primed queries in the SCassandra cluster
+   */
+  void remove_primed_queries();
+
+  /**
+   * Remove the primed queries on a given node in the SCassandra cluster
+   *
+   * @param node Node to remove primed queries from
+   */
+  void remove_primed_queries(unsigned int node);
+
+private:
+  typedef std::map<unsigned int, Process> ProcessMap;
+  typedef std::pair<unsigned int, Process> ProcessPair;
+  typedef std::map<unsigned int, std::vector<Process*> > PeersMap;
+  typedef std::pair<unsigned int, std::vector<Process*> > PeersPair;
+  /**
+   * Processes for each node in the SCassandra cluster
+   */
+  ProcessMap processes_;
+  /**
+   * Peers for a node in the SCassandra cluster
+   */
+  PeersMap peers_;
+  /**
+   * Cassandra release version
+   */
+  std::string release_version_;
+  /**
+   * Schema version
+   */
+  std::string schema_version_;
+  /**
+   * Mutex for process piped buffer allocation and reads
+   */
+  static uv_mutex_t mutex_;
+
+#if UV_VERSION_MAJOR == 0
+  /**
+   * uv_read_start callback for allocating memory for the buffer in the pipe
+   *
+   * @param handle Handle information for the pipe being read
+   * @param suggested_size Suggested size for the buffer
+   */
+  static uv_buf_t handle_allocation(uv_handle_t* handle, size_t suggested_size);
+#else
+  /**
+   * uv_read_start callback for allocating memory for the buffer in the pipe
+   *
+   * @param handle Handle information for the pipe being read
+   * @param suggested_size Suggested size for the buffer
+   * @param buffer Buffer to allocate bytes for
+   */
+  static void handle_allocation(uv_handle_t* handle, size_t suggested_size,
+    uv_buf_t* buffer);
+#endif
+
+  /**
+   * uv_spawn callback for handling the completion of the process
+   *
+   * @param process Process
+   * @param error_code Error/Exit code
+   * @param term_signal Terminating signal
+   */
+#if UV_VERSION_MAJOR == 0
+  static void handle_exit(uv_process_t* process, int error_code,
+    int term_signal);
+#else
+  static void handle_exit(uv_process_t* process, int64_t error_code,
+    int term_signal);
+#endif
+
+  /**
+   * uv_read_start callback for processing the buffer in the pipe
+   *
+   * @param stream Stream to process (stdout/stderr)
+   * @param buffer_length Length of the buffer
+   * @param buffer Buffer to process
+   */
+#if UV_VERSION_MAJOR == 0
+  static void handle_read(uv_stream_t* stream, ssize_t buffer_length,
+    uv_buf_t buffer);
+#else
+  static void handle_read(uv_stream_t* stream, ssize_t buffer_length,
+    const uv_buf_t* buffer);
+#endif
+
+  /**
+   * uv_thread_create callback for executing the SCassandra process
+   *
+   * @param arg Information to start the SCassandra process
+   */
+  static void handle_thread_create(void* arg);
+
+  /**
+   * Create/Initialize the SCassandra processes for each node
+   *
+   * @param nodes Data center(s) to create in the SCassandra cluster
+   */
+  void create_processes(std::vector<unsigned int> nodes);
+
+  /**
+   * DELETE request to send to the SCassandra REST server
+   *
+   * @param node Node to send request to
+   * @param endpoint The endpoint (URI) for the request
+   * @throws SCassandraCluster::Exception
+   */
+  void send_delete(unsigned int node, const std::string& endpoint);
+
+  /**
+   * GET request to send to the SCassandra REST server
+   *
+   * @param node Node to send request to
+   * @param endpoint The endpoint (URI) for the request
+   * @throws SCassandraCluster::Exception
+   */
+  const std::string send_get(unsigned int node, const std::string& endpoint);
+
+  /**
+   * POST request to send to the SCassandra REST server.
+   *
+   * @param node Node to send request to
+   * @param endpoint The endpoint (URI) for the request
+   * @param content The content of the POST
+   * @throws SCassandraCluster::Exception
+   */
+  void send_post(unsigned int node, const std::string& endpoint,
+    const std::string& content);
+
+  /**
+   * Send the request to the SCassandra REST server
+   *
+   * @param method Type of request to send to the REST server
+   * @param node Node to send request to
+   * @param request Request to send to the REST server
+   * @param content The content of the request (default: empty)
+   * @return REST server response
+   * @throws SCassandraCluster::Exception
+   */
+  Response send_request(Request::Method method, unsigned int node,
+    const std::string& endpoint, const std::string& content = "");
+
+  /**
+   * Determine if a node is available
+   *
+   * @param node SCassandra node to check
+   * @return True if node is available; false otherwise
+   * @throws Exception if node is not valid or process is not running
+   */
+  bool is_node_available(unsigned int node);
+
+  /**
+   * Determine if a node is available
+   *
+   * @param ip_address IPv4 address of the SCassandra node
+   * @param port Port of the SCassandra node
+   * @return True if node is available; false otherwise
+   */
+  bool is_node_available(const std::string& ip_address, unsigned short port);
+
+  /**
+   * Generate the token ranges (no v-nodes) for a single data center
+   *
+   * @param nodes Data center to generate tokens for
+   * @param nodes Number of nodes to generate tokens for
+   * @return Token ranges for each node
+   */
+  std::vector<std::string> generate_token_ranges(unsigned int data_center,
+    unsigned int nodes);
+
+  /**
+   * Prime the system tables (local and peers) on the selected node
+   *
+   * @param node Node being primed
+   */
+  void prime_system_tables(unsigned int node);
+};
+
+} // namespace test
+
+#endif
+
+#endif // __TEST_SCASSANDRA_CLUSTER_HPP__

--- a/tests/src/integration/scassandra/scassandra_integration.cpp
+++ b/tests/src/integration/scassandra/scassandra_integration.cpp
@@ -1,0 +1,151 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#include "scassandra_integration.hpp"
+#include "priming_requests.hpp"
+#include "win_debug.hpp"
+
+// Initialize the static member variables
+SharedPtr<test::SCassandraCluster> SCassandraIntegration::scc_ = NULL;
+bool SCassandraIntegration::is_scc_started_ = false;
+const PrimingRequest SCassandraIntegration::mock_query_ = PrimingRequest::builder()
+  .with_query("mock query")
+  .with_rows(PrimingRows::builder()
+    .add_row(PrimingRow::builder()
+      .add_column("SUCCESS", CASS_VALUE_TYPE_BOOLEAN, "TRUE")
+    )
+  );
+
+SCassandraIntegration::SCassandraIntegration()
+  : is_scc_start_requested_(true)
+  , is_scc_for_test_case_(true) {
+}
+
+SCassandraIntegration::~SCassandraIntegration() {
+}
+
+void SCassandraIntegration::SetUpTestCase() {
+  try {
+    scc_ = new test::SCassandraCluster();
+  } catch (SCassandraCluster::Exception scce) {
+    FAIL() << scce.what();
+  }
+}
+
+void SCassandraIntegration::SetUp() {
+  CHECK_SCC_AVAILABLE;
+
+  // Initialize the SCassandra cluster instance
+  if (is_scc_start_requested_) {
+    // Start the SCC
+    default_start_scc();
+
+    // Prime the system tables (local and peers))
+    scc_->prime_system_tables();
+
+    // Generate the default contact points
+    contact_points_ = scc_->cluster_contact_points();
+  }
+
+  // Determine if the session connection should be established
+  if (is_session_requested_) {
+    if (is_scc_started_) {
+      connect();
+    } else {
+      LOG_ERROR("Connection to SCassandra Cluster Aborted: SCC has not been started");
+    }
+  }
+}
+
+//void SCassandraIntegration::TearDownTestCase() {
+//  CHECK_SCC_AVAILABLE;
+//
+//  scc_->destroy_cluster();
+//  is_scc_started_ = false;
+//}
+
+void SCassandraIntegration::TearDown() {
+  CHECK_SCC_AVAILABLE;
+
+  session_.close();
+
+  // Reset the SCassandra cluster (if not being used for the entire test case)
+  scc_->reset_cluster();
+  if (!is_scc_for_test_case_) {
+    scc_->destroy_cluster();
+    is_scc_started_ = false;
+  }
+}
+
+test::driver::Cluster SCassandraIntegration::default_cluster() {
+  return Integration::default_cluster()
+    .with_connection_heartbeat_interval(0);
+}
+
+void SCassandraIntegration::default_start_scc() {
+  // Create the data center nodes vector and start the SCC
+  std::vector<unsigned int> data_center_nodes;
+  data_center_nodes.push_back(number_dc1_nodes_);
+  data_center_nodes.push_back(number_dc2_nodes_);
+  start_scc(data_center_nodes);
+}
+
+void SCassandraIntegration::start_scc(std::vector<unsigned int>
+  data_center_nodes /*= SCassandraCluster::DEFAULT_DATA_CENTER_NODES*/) {
+  // Ensure the SCC is only started once (process handling)
+  if (!is_scc_started_) {
+    // Create and start the SCC
+    MemoryLeakListener::disable();
+    scc_->create_cluster(data_center_nodes);
+    scc_->start_cluster();
+    MemoryLeakListener::enable();
+    is_scc_started_ = true;
+  }
+}
+
+test::driver::Result SCassandraIntegration::execute_mock_query(
+  CassConsistency consistency /*= CASS_CONSISTENCY_ONE*/) {
+  return session_.execute("mock query", consistency, false, false);
+}
+
+void SCassandraIntegration::prime_mock_query(unsigned int node /*= 0*/) {
+  // Create the mock query
+  PrimingRequest mock_query = mock_query_;
+  mock_query.with_result(PrimingResult::SUCCESS);
+
+  // Determine if this is targeting a particular node
+  if (node > 0) {
+    scc_->prime_query(node, mock_query);
+  } else {
+    scc_->prime_query(mock_query);
+  }
+}
+
+void SCassandraIntegration::prime_mock_query_with_error(PrimingResult result,
+  unsigned int node /*= 0*/) {
+  // Create the mock query
+  PrimingRequest mock_query = mock_query_;
+  mock_query.with_result(result);
+
+  // Determine if this is targeting a particular node
+  if (node > 0) {
+    // Send the simulated error to the SCassandra node
+    scc_->prime_query(node, mock_query);
+
+    // Update the primed query to be successful on the other node
+    std::vector<unsigned int> nodes = scc_->nodes();
+    for (std::vector<unsigned int>::iterator iterator = nodes.begin();
+      iterator != nodes.end(); ++iterator) {
+      unsigned int current_node = *iterator;
+      if (current_node != node) {
+        prime_mock_query(current_node);
+      }
+    }
+  } else {
+    scc_->prime_query(mock_query);
+  }
+}

--- a/tests/src/integration/scassandra/scassandra_integration.hpp
+++ b/tests/src/integration/scassandra/scassandra_integration.hpp
@@ -1,0 +1,141 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __SCASSANDRA_INTEGRATION_HPP__
+#define __SCASSANDRA_INTEGRATION_HPP__
+#include "integration.hpp"
+#include "scassandra_cluster.hpp"
+
+#include <uv.h>
+
+// Macros to use for grouping SCassandra integration tests together
+#define SCASSANDRA_TEST_NAME(test_name) Integration##_##SCassandra##_##test_name
+#define SCASSANDRA_INTEGRATION_TEST_F(test_case, test_name) \
+  INTEGRATION_TEST_F(SCassandra, test_case, test_name)
+#define SCASSANDRA_INTEGRATION_TYPED_TEST_P(test_case, test_name) \
+  INTEGRATION_TYPED_TEST_P(SCassandra, test_case, test_name)
+
+#define CHECK_SCC_AVAILABLE \
+  if (!scc_) { \
+    return; \
+  }
+
+#define SKIP_TEST_IF_SCC_UNAVAILABLE \
+  if (!scc_) { \
+    SKIP_TEST("SCassandra is unavailable"); \
+  }
+
+/**
+ * Base class to provide common integration test functionality for tests against
+ * SCassandra (Stubbed Cassandra)
+ */
+class SCassandraIntegration : public Integration {
+public:
+
+  SCassandraIntegration();
+
+  ~SCassandraIntegration();
+
+  static void SetUpTestCase();
+
+  void SetUp();
+
+  void TearDown();
+
+  //static void TearDownTestCase();
+
+protected:
+  /**
+   * SCassandra cluster (manager) instance
+   */
+  static SharedPtr<test::SCassandraCluster> scc_;
+  /**
+   * Setting to determine if SCassandra cluster should be started. True if
+   * SCassandracluster should be started; false otherwise.
+   * (DEFAULT: true)
+   */
+  bool is_scc_start_requested_;
+  /**
+   * Setting to determine if SCassandra cluster is being used for the entire
+   * test case or if it should be re-initialized per test. True if for the
+   * test case; false otherwise.
+   * (DEFAULT: true)
+   */
+  bool is_scc_for_test_case_;
+
+  /**
+   * Get the default cluster configuration
+   *
+   * @return Cluster object (default)
+   */
+  virtual Cluster default_cluster();
+
+  /**
+   * Default start procedures for the SCassandra cluster (based on the number of
+   * nodes in the standard two data center configuration for the test harness)
+   */
+  void default_start_scc();
+
+  /**
+   * Perform the start procedures for the SCassandra cluster with the given
+   * data center configuration
+   *
+   * @param data_center_nodes Data center(s) to create in the SCassandra cluster
+   *                          (default: 1 data center with 1 node)
+   */
+  void start_scc(std::vector<unsigned int> data_center_nodes = SCassandraCluster::DEFAULT_DATA_CENTER_NODES);
+
+  /**
+   * Execute a mock query at a given consistency level
+   *
+   * @param consistency Consistency level to execute mock query at
+   * @return Result object
+   * @see prime_mock_query Primes all nodes with a successful mock query
+   * @see prime_mock_query_with_error Primes the given node with with an error
+   *                                  for the mock query and primes the
+   *                                  remaining nodes with a successful mock
+   *                                  query
+   */
+  virtual test::driver::Result execute_mock_query(
+    CassConsistency consistency = CASS_CONSISTENCY_ONE);
+
+  /**
+   * Prime the successful mock query on the given node
+   *
+   * @param node Node to apply the successful mock query on; if node == 0 the
+   *             successful mock query will be applied to all nodes in the
+   *             SCassandra cluster
+   *             (DEFAULT: 0 - Apply mock query with success to all nodes
+   */
+
+  void prime_mock_query(unsigned int node = 0);
+  /**
+   * Prime the mock query with a simulated error result on the given node while
+   * priming the remaining nodes in the SCassandra cluster with a successful
+   * mock query
+   *
+   * @param result Resulting error to apply to the given node
+   * @param node Node to apply the error on; if node == 0 the mock query will
+   *             be applied to all nodes in the SCassandra cluster with the
+   *             resulting error
+   *             (DEFAULT: 0 - Apply mock query with error to all nodes
+   */
+  void prime_mock_query_with_error(PrimingResult result, unsigned int node = 0);
+
+private:
+  /**
+   * Flag to determine if the SCassandra cluster instance has already been
+   * started
+   */
+  static bool is_scc_started_;
+  /**
+   * A mocked query without the PrimingResult assigned
+   */
+  static const PrimingRequest mock_query_;
+};
+
+#endif //__SCASSANDRA_INTEGRATION_HPP__

--- a/tests/src/integration/scassandra/scassandra_rest_client.cpp
+++ b/tests/src/integration/scassandra/scassandra_rest_client.cpp
@@ -1,0 +1,219 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#include "scassandra_rest_client.hpp"
+#include "test_utils.hpp"
+
+#include "address.hpp"
+
+#include <sstream>
+
+#if UV_VERSION_MAJOR == 0
+# define UV_ERRSTR(status, loop) std::string(uv_strerror(uv_last_error(loop)))
+#else
+# define UV_ERRSTR(status, loop) std::string(uv_strerror(status))
+#endif
+
+#define HTTP_EOL "\r\n"
+#define OUTPUT_BUFFER_SIZE 10240
+
+// Static initializations
+uv_buf_t SCassandraRestClient::write_buf_;
+uv_write_t SCassandraRestClient::write_req_;
+
+/**
++ * HTTP request
++ */
+struct HttpRequest {
+  /**
+   * HTTP message to submit to the SCassandra REST server
+   */
+  std::string message;
+  /**
+   * libuv loop (for processing errors)
+   */
+  uv_loop_t* loop;
+  /**
+   * HTTP response for sent request
+   */
+  Response response;
+};
+
+const Response SCassandraRestClient::send_request(Request request) {
+    // Initialize the loop
+#if UV_VERSION_MAJOR == 0
+  uv_loop_t* loop = uv_loop_new();
+#else
+  uv_loop_t loop;
+  int error_code = uv_loop_init(&loop);
+  if(error_code != 0) {
+    throw Exception("Unable to Send Request: " + UV_ERRSTR(error_code, loop));
+  };
+#endif
+
+  // Initialize the HTTP request
+  HttpRequest http_request;
+  http_request.message = generate_http_message(request);
+#if UV_VERSION_MAJOR == 0
+  http_request.loop = loop;
+#else
+  http_request.loop = &loop;
+#endif
+
+  // Create the IPv4 socket address
+  const cass::Address address(request.address, static_cast<int>(request.port));
+
+  // Initialize the client TCP request
+  uv_tcp_t tcp;
+  tcp.data = &http_request;
+#if UV_VERSION_MAJOR == 0
+  int error_code = uv_tcp_init(loop, &tcp);
+#else
+  error_code = uv_tcp_init(&loop, &tcp);
+#endif
+  if (error_code != 0) {
+    LOG_ERROR("Unable to Initialize TCP Request: "
+      << UV_ERRSTR(error_code, loop));
+  }
+  error_code = uv_tcp_keepalive(&tcp, 1, 60);
+  if (error_code != 0) {
+    LOG_ERROR("Unable to Set TCP KeepAlive: " << UV_ERRSTR(error_code, loop));
+  }
+
+  // Start the request and attach the HTTP request to send to the REST server
+  uv_connect_t connect;
+  connect.data = &http_request;
+#if UV_VERSION_MAJOR == 0
+  uv_tcp_connect(&connect, &tcp,
+    *address.addr_in(),
+    handle_connected);
+#else
+  uv_tcp_connect(&connect, &tcp,
+    address.addr(),
+    handle_connected);
+#endif
+
+#if UV_VERSION_MAJOR == 0
+    uv_run(loop, UV_RUN_DEFAULT);
+    uv_loop_delete(loop);
+#else
+    uv_run(&loop, UV_RUN_DEFAULT);
+    uv_loop_close(&loop);
+#endif
+
+  // Return the response from the request
+  return http_request.response;
+}
+
+#if UV_VERSION_MAJOR == 0
+uv_buf_t SCassandraRestClient::handle_allocation(uv_handle_t* handle,
+  size_t suggested_size) {
+  return uv_buf_init(new char[suggested_size], suggested_size);
+#else
+void SCassandraRestClient::handle_allocation(uv_handle_t* handle, size_t suggested_size,
+  uv_buf_t* buffer) {
+  buffer->base = new char[OUTPUT_BUFFER_SIZE];
+  buffer->len = OUTPUT_BUFFER_SIZE;
+#endif
+}
+
+void SCassandraRestClient::handle_connected(uv_connect_t* req, int status) {
+  HttpRequest* request = static_cast<HttpRequest*>(req->data);
+
+  if (status < 0) {
+    LOG_ERROR("Unable to Connect to HTTP Server: "
+      << UV_ERRSTR(status, request->loop));
+    uv_close(reinterpret_cast<uv_handle_t*>(req->handle), NULL);
+  } else {
+
+    // Create the buffer to write to the stream
+    write_buf_.base = const_cast<char*>(request->message.c_str());
+    write_buf_.len = request->message.size();
+
+    // Send the HTTP request
+    uv_read_start(req->handle, handle_allocation, handle_response);
+    uv_write(&write_req_, req->handle, &write_buf_, 1, NULL);
+  }
+}
+
+#if UV_VERSION_MAJOR == 0
+void SCassandraRestClient::handle_response(uv_stream_t* stream, ssize_t buffer_length,
+  uv_buf_t buffer) {
+#else
+void SCassandraRestClient::handle_response(uv_stream_t* stream, ssize_t buffer_length,
+  const uv_buf_t* buffer) {
+#endif
+  HttpRequest* request = static_cast<HttpRequest*>(stream->data);
+
+  if (buffer_length > 0) {
+    // Process the buffer and log it
+#if UV_VERSION_MAJOR == 0
+    std::string server_response = std::string(buffer.base, buffer_length);
+#else
+    std::string server_response = std::string(buffer->base, buffer_length);
+#endif
+    LOG_DEBUG(test::Utils::trim(server_response));
+
+    // Parse the status code and content of the response
+    std::istringstream lines(server_response);
+    std::string current_line;
+    while (std::getline(lines, current_line)) {
+      // Determine if the status code should be assigned in the response
+      if (current_line.compare(0, 4, "HTTP") == 0) {
+        // Status-Line = HTTP-Version <SPC> Status-Code <SPC> Reason-Phrase
+        std::stringstream status_code;
+        status_code << test::Utils::explode(current_line, ' ').at(1);
+        if ((status_code >> request->response.status_code).fail()) {
+          LOG_ERROR("Unable to Determine Status Code: " << current_line);
+        }
+      } else if (current_line.compare(0, 1, "\r") == 0) {
+        while (std::getline(lines, current_line)) {
+          request->response.message.append(test::Utils::trim(current_line));
+        }
+      }
+    }
+  } else if (buffer_length < 0) {
+#if UV_VERSION_MAJOR == 0
+    uv_err_t error = uv_last_error(request->loop);
+    if (error.code == UV_EOF) // uv_close if UV_EOF
+#endif
+    uv_close(reinterpret_cast<uv_handle_t*>(stream), NULL);
+  }
+
+  // Clean up the memory allocated
+#if UV_VERSION_MAJOR == 0
+  delete[] buffer.base;
+#else
+  delete[] buffer->base;
+#endif
+}
+
+const std::string SCassandraRestClient::generate_http_message(Request request) {
+  // Determine the method of the the request
+  std::stringstream message;
+  if (request.method == Request::HTTP_METHOD_DELETE) {
+    message << "DELETE";
+  } else if (request.method == Request::HTTP_METHOD_GET) {
+    message << "GET";
+  } else if (request.method == Request::HTTP_METHOD_POST) {
+    message << "POST";
+  }
+  message << " /" << request.endpoint << " HTTP/1.1" << HTTP_EOL;
+
+  // Generate the headers
+  bool is_post = request.method == Request::HTTP_METHOD_POST;
+  message
+    << "Host: " << request.address << ":" << request.port << HTTP_EOL
+    << (is_post ? "Content-Type: application/json" HTTP_EOL : "")
+    << "Content-Length: "<< ((is_post) ? request.content.size() : 0) << HTTP_EOL
+    << "Connection: close" << HTTP_EOL << HTTP_EOL
+    << (is_post ? request.content : "");
+
+  // Return the HTTP message
+  LOG_DEBUG("[HTTP Message]: " << message.str());
+  return message.str();
+}

--- a/tests/src/integration/scassandra/scassandra_rest_client.hpp
+++ b/tests/src/integration/scassandra/scassandra_rest_client.hpp
@@ -1,0 +1,166 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __SCASSANDRA_REST_CLIENT_HPP__
+#define __SCASSANDRA_REST_CLIENT_HPP__
+
+#include "exception.hpp"
+
+#include <string>
+
+#include <uv.h>
+
+/**
++ * SCassandra REST request
++ */
+struct Request {
+  /**
+   * HTTP request method
+   */
+  enum Method {
+    /**
+     * HTTP DELETE request method
+     */
+    HTTP_METHOD_DELETE = 0,
+    /**
+     * HTTP GET request method
+     */
+    HTTP_METHOD_GET,
+    /**
+     * HTTP POST request method
+     */
+    HTTP_METHOD_POST
+  };
+
+  /**
+   * Host address IPv4
+   */
+  std::string address;
+  /**
+   * Host port
+   */
+  unsigned short port;
+  /**
+   * JSON message to put in the POST request content
+   */
+  std::string content;
+  /**
+   * The endpoint (URI) for the request
+   */
+  std::string endpoint;
+  /**
+   * HTTP request type to use for the request
+   */
+  Method method;
+};
+
+struct Response {
+  /**
+   * JSON result message
+   */
+  std::string message;
+  /**
+   * Status code/response for the HTTP request
+   */
+  int status_code;
+
+  Response()
+    : status_code(200 /*OK*/) {}
+};
+
+/**
+ * Simple HTTP client for sending synchronous requests to a HTTP SCassandra
+ * REST server
+ */
+class SCassandraRestClient {
+public:
+  class Exception : public test::Exception {
+  public:
+    Exception(const std::string& message)
+      : test::Exception(message) {}
+  };
+
+  /**
+   * Send/Submit the request to the SCassandra REST server
+   *
+   * @param request The request to send
+   * @return The response from the request
+   */
+  static const Response send_request(Request request);
+
+private:
+  /**
+   * libuv write buffer
+   */
+  static uv_buf_t write_buf_;
+  /**
+   * libuv write request handle
+   */
+  static uv_write_t write_req_;
+  /**
+   * Disable the default constructor
+   */
+  SCassandraRestClient();
+
+#if UV_VERSION_MAJOR == 0
+  /**
+   * Handle the buffer allocation of memory for the requests and server
+   * responses.
+   *
+   * @param handle The libuv handle type
+   * @param suggested_size The size (in bytes) to allocate for the buffer
+   * @return The allocated buffer (must be freed)
+   */
+  static uv_buf_t handle_allocation(uv_handle_t* handle, size_t suggested_size);
+#else
+  /**
+   * Handle the buffer allocation of memory for the requests and server
+   * responses.
+   *
+   * @param handle The libuv handle type
+   * @param suggested_size The size (in bytes) to allocate for the buffer
+   * @param buf Buffer to be allocated
+   */
+  static void handle_allocation(uv_handle_t* handle, size_t suggested_size,
+    uv_buf_t* buffer);
+#endif
+
+  /**
+   * Handle the connect (callback) when the connection has been established to
+   * the REST server of SCassandra.
+   *
+   * @param req Connection request type
+   * @param status 0 if connection was successful; < 0 otherwise
+   */
+  static void handle_connected(uv_connect_t* req, int status);
+
+  /**
+   * Handle the response (callback) of the data coming from the stream/socket.
+   *
+   * @param stream Stream handle type
+   * @param nread > 0 if data is available (can be read); < 0 otherwise.
+   *              NOTE: When there is no more data in the stream <b>nread</b>
+   *              will equal <b>UV_EOF</b>
+   * @param buf Buffer to read from
+   */
+#if UV_VERSION_MAJOR == 0
+  static void handle_response(uv_stream_t* strean, ssize_t nread, uv_buf_t buf);
+#else
+  static void handle_response(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
+#endif
+
+  /**
+   * Generate the HTTP message for the REST request.
+   *
+   * @param request Request to generate message from
+   * @return String representing the REST request HTTP message
+   */
+  static const std::string generate_http_message(Request request);
+
+};
+
+#endif // __SCASSANDRA_REST_CLIENT_HPP__

--- a/tests/src/integration/test_category.cpp
+++ b/tests/src/integration/test_category.cpp
@@ -1,0 +1,129 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+#include "test_category.hpp"
+
+#include <algorithm>
+#include <climits>
+
+// Constant value definitions for test type
+const TestCategory TestCategory::CASSANDRA("CASSANDRA", 0, "Cassandra", "*_Cassandra_*");
+const TestCategory TestCategory::DSE("DSE", 1, "DataStax Enterprise", "*_DSE_*");
+const TestCategory TestCategory::SCASSANDRA("SCASSANDRA", SHRT_MAX, "Stubbed Cassandra", "*_SCassandra_*");
+
+// Static declarations for test type
+std::set<TestCategory> TestCategory::constants_;
+
+std::ostream& operator<<(std::ostream& os, const TestCategory& object) {
+  os << object.display_name();
+  return os;
+}
+
+TestCategory::TestCategory()
+  : name_("INVALID")
+  , ordinal_(-1)
+  , display_name_("Invalid test category")
+  , filter_("*") {}
+
+TestCategory::TestCategory(const std::string& name) {
+  *this = name;
+}
+
+const std::string& TestCategory::name() const {
+  return name_;
+}
+
+short TestCategory::ordinal() const {
+  return ordinal_;
+}
+
+const std::string& TestCategory::display_name() const {
+  return display_name_;
+}
+
+const std::string& TestCategory::filter() const {
+  return filter_;
+}
+
+void TestCategory::operator =(const TestCategory& object) {
+  name_ = object.name_;
+  ordinal_ = object.ordinal_;
+  display_name_ = object.display_name_;
+}
+
+void TestCategory::operator=(const std::string& name) {
+  *this = get_enumeration(name);
+}
+
+bool TestCategory::operator<(const TestCategory& object) const {
+  return ordinal_ < object.ordinal_;
+}
+
+bool TestCategory::operator==(const TestCategory& object) const {
+  if (name_ == object.name_) {
+    if (ordinal_ == object.ordinal_) {
+      if (display_name_ == object.display_name_) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool TestCategory::operator==(const std::string& object) const {
+  std::string lhs = name_;
+  std::string rhs = object;
+  std::transform(lhs.begin(), lhs.end(), lhs.begin(), ::tolower);
+  std::transform(rhs.begin(), rhs.end(), rhs.begin(), ::tolower);
+  return lhs.compare(rhs) == 0;
+}
+
+bool TestCategory::operator !=(const TestCategory& object) const {
+  return !(*this == object);
+}
+
+bool TestCategory::operator !=(const std::string& object) const {
+  return !(*this == object);
+}
+
+TestCategory::iterator TestCategory::begin() {
+    return get_constants().begin();
+  }
+
+TestCategory::iterator TestCategory::end() {
+  return get_constants().end();
+}
+
+TestCategory::TestCategory(const std::string& name, short ordinal,
+  const std::string& display_name, const std::string& filter)
+  : name_(name)
+  , ordinal_(ordinal)
+  , display_name_(display_name)
+  , filter_(filter) {}
+
+const std::set<TestCategory>& TestCategory::get_constants() {
+  if (constants_.empty()) {
+    constants_.insert(CASSANDRA);
+    constants_.insert(DSE);
+    constants_.insert(SCASSANDRA);
+  }
+
+  return constants_;
+}
+
+TestCategory TestCategory::get_enumeration(const std::string& name)  const{
+  // Iterator over the constants and find the corresponding enumeration
+  if (!name.empty()) {
+    for (iterator iterator = begin(); iterator != end(); ++iterator) {
+      if (*iterator == name) {
+        return *iterator;
+      }
+    }
+  }
+
+  // Enumeration was not found; throw exception if not
+  throw Exception(name + " is not a valid test category");
+}

--- a/tests/src/integration/test_category.hpp
+++ b/tests/src/integration/test_category.hpp
@@ -1,0 +1,195 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#ifndef __TEST_CATEGORY_HPP__
+#define __TEST_CATEGORY_HPP__
+#include "exception.hpp"
+
+#include <ostream>
+#include <set>
+#include <string>
+
+/**
+ * Test category enumeration
+ */
+class TestCategory {
+public:
+  class Exception : public test::Exception {
+  public:
+    Exception(const std::string& message)
+      : test::Exception(message) {}
+  };
+  /**
+   * Iterator
+   */
+  typedef std::set<TestCategory>::iterator iterator;
+  /**
+   * Cassandra category
+   */
+  static const TestCategory CASSANDRA;
+  /**
+   * DataStax Enterprise category
+   */
+  static const TestCategory DSE;
+  /**
+   * Stubbed Cassandra category
+   */
+  static const TestCategory SCASSANDRA;
+
+  /**
+   * Default constructor to handle issues with static initialization of
+   * constant enumerations
+   */
+  TestCategory();
+  /**
+   * Construct the enumeration from the given name
+   *
+   * @param name Enumeration name
+   */
+  TestCategory(const std::string& name);
+  /**
+   * Name of constant
+   *
+   * @return Name of constant
+   */
+  const std::string& name() const;
+  /**
+   * Ordinal of constant
+   *
+   * @return Ordinal of constant
+   */
+  short ordinal() const;
+  /**
+   * Get the display name
+   *
+   * @return Display name of the enumeration
+   */
+  const std::string& display_name() const;
+  /**
+   * Get the filter associated with the enumeration
+   *
+   * @return Filter for the enumeration
+   */
+  const std::string& filter() const;
+  /**
+   * First item in the enumeration constants
+   *
+   * @return Iterator pointing to the first element in the set
+   */
+  static iterator begin();
+  /**
+   * Last item in the enumeration constants
+   *
+   * @return Iterator pointing to the last element in the set
+   */
+  static iterator end();
+
+  /**
+   * Assign
+   *
+   * @param object Right hand side comparison object
+   */
+  void operator=(const TestCategory& object);
+  /**
+   * Assign
+   *
+   * @param object Right hand side comparison object
+   */
+  void operator=(const std::string& object);
+  /**
+   * Less than (can be used for sorting)
+   *
+   * @param object Right hand side comparison object
+   * @return True if LHS < RHS; false otherwise
+   */
+  bool operator<(const TestCategory& object) const;
+  /**
+   * Equal to
+   *
+   * @param object Right hand side comparison object
+   * @return True if LHS == RHS; false otherwise
+   */
+  bool operator==(const TestCategory& object) const;
+  /**
+   * Equal to (case-incentive string comparison)
+   *
+   * @param object Right hand side comparison object
+   * @return True if LHS == RHS; false otherwise
+   */
+  bool operator==(const std::string& object) const;
+  /**
+   * Not equal to
+   *
+   * @param object Right hand side comparison object
+   * @return True if LHS != RHS; false otherwise
+   */
+  bool operator!=(const TestCategory& object) const;
+  /**
+   * Not equal to (case-incentive string comparison)
+   *
+   * @param object Right hand side comparison object
+   * @return True if LHS != RHS; false otherwise
+   */
+  bool operator!=(const std::string& object) const;
+
+  /**
+   * Stream operator (out)
+   *
+   * @param os Output stream
+   * @param object Object to write to stream
+   * @return Output stream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TestCategory& object);
+
+private:
+  /**
+   * Enumeration constants
+   */
+  static std::set<TestCategory> constants_;
+  /**
+   * Name of constant
+   */
+  std::string name_;
+  /**
+   * Ordinal of constant
+   */
+  short ordinal_;
+  /**
+   * Display name for constant
+   */
+  std::string display_name_;
+  /**
+   * Filter for constant
+   */
+  std::string filter_;
+
+  /**
+   * Constructor
+   *
+   * @param name Name for enumeration
+   * @param ordinal Ordinal value for enumeration
+   * @param display_name Display name for enumeration
+   * @param filter Filter for enumeration
+   */
+  TestCategory(const std::string& name, short ordinal,
+    const std::string& display_name, const std::string& filter);
+  /**
+   * Get the enumeration constants
+   *
+   * @return List of enumeration constants
+   */
+  static const std::set<TestCategory>& get_constants();
+  /**
+   * Get the enumeration based on the name
+   *
+   * @param name Name of the enumeration (case-insensitive)
+   * @return Enumeration constant
+   */
+  TestCategory get_enumeration(const std::string& name) const;
+};
+
+#endif // __TEST_CATEGORY_HPP__

--- a/tests/src/integration/test_utils.hpp
+++ b/tests/src/integration/test_utils.hpp
@@ -19,10 +19,12 @@
 #define SUFFIX_LOG std::endl
 #ifdef INTEGRATION_VERBOSE_LOGGING
 # define LOG(message) PREFIX_LOG << PREFIX_MESSAGE << message << SUFFIX_LOG
+# define LOG_DEBUG(message) PREFIX_LOG << PREFIX_MESSAGE << "DEBUG: " << message << SUFFIX_LOG
 # define LOG_WARN(message) PREFIX_LOG << PREFIX_MESSAGE << "WARN: " << message << SUFFIX_LOG
 #else
 # define LOG_DISABLED do {} while (false)
 # define LOG(message) LOG_DISABLED
+# define LOG_DEBUG(message) LOG_DISABLED
 # define LOG_WARN(message) LOG_DISABLED
 #endif
 #define LOG_ERROR(message) PREFIX_LOG << PREFIX_MESSAGE << "ERROR: " \

--- a/tests/src/integration/test_utils.hpp
+++ b/tests/src/integration/test_utils.hpp
@@ -7,6 +7,7 @@
 
 #ifndef __TEST_UTILS_HPP__
 #define __TEST_UTILS_HPP__
+#include <iostream>
 #include <string>
 #include <vector>
 

--- a/tests/src/integration/tests/scassandra/test_scassandra_connect.cpp
+++ b/tests/src/integration/tests/scassandra/test_scassandra_connect.cpp
@@ -1,0 +1,297 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#include "scassandra_integration.hpp"
+
+#define CORE_CONNECTIONS_PER_HOST 32
+
+/**
+ * Connection integration tests using SCassandra
+ */
+class ConnectionTest : public SCassandraIntegration {
+public:
+  void SetUp() {
+    is_scc_start_requested_ = false;
+    is_scc_for_test_case_ = false;
+    is_session_requested_ = false;
+    SCassandraIntegration::SetUp();
+  }
+
+  /**
+   * Assert/Validate the active connections on the SCassandra cluster
+   *
+   * @param host_connections Connections per host (expected connections)
+   */
+  void assert_active_connections(int host_connections = 1) {
+    for (size_t n = 0; n < scc_->nodes().size(); ++n) {
+      // Determine if control connection is being asserted
+      size_t connections = (n == 0 ? host_connections + 1 : host_connections);
+      ASSERT_EQ(connections, scc_->active_connections(n + 1).size());
+    }
+  }
+
+  /**
+   * Start the SCC, prime the tables and establish a connection to the
+   * SCassandra with the given data center configuration
+   *
+   * @param data_center_nodes Data center(s) to create in the SCassandra cluster
+   * @param cluster Cluster configuration to use when establishing the
+   *                connection (default: NULL; uses default configuration)
+   */
+  void connect(std::vector<unsigned int> data_center_nodes,
+    test::driver::Cluster cluster = NULL) {
+    // Start the SCC, prime the tables, and establish a connection
+    start_scc(data_center_nodes);
+    scc_->prime_system_tables();
+    contact_points_ = scc_->cluster_contact_points();
+    if (!cluster) {
+      Integration::connect();
+    } else {
+      cluster.with_contact_points(scc_->cluster_contact_points());
+      Integration::connect(cluster);
+    }
+  }
+
+  /**
+   * Start the SCC, prime the tables and establish a connection to the
+   * SCassandra with the given data center configuration
+   *
+   * @param number_dc1_nodes Number of nodes in data center one
+   * @param number_dc2_nodes Number of nodes in data center two
+   * @param cluster Cluster configuration to use when establishing the
+   *                connection (default: NULL; uses default configuration)
+   */
+  void connect(unsigned int number_dc1_nodes, unsigned int number_dc2_nodes,
+    test::driver::Cluster cluster = NULL) {
+    // Initialize the number of nodes in the standard data centers
+    std::vector<unsigned int> data_center_nodes;
+    number_dc1_nodes_ = number_dc1_nodes;
+    number_dc2_nodes_ = number_dc2_nodes;
+    data_center_nodes.push_back(number_dc1_nodes_);
+    data_center_nodes.push_back(number_dc2_nodes_);
+
+    // Perform the connection
+    connect(data_center_nodes, cluster);
+  }
+};
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains one
+ * node and validate the number of active connections (including control
+ * connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest, ConnectOneNode) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  connect(1, 0);
+  assert_active_connections();
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * three nodes and validate the number of active connections (including control
+ * connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest, ConnectThreeNodes) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  connect(3, 0);
+  assert_active_connections();
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * one node on each data center and validate the number of active connections
+ * (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest, ConnectOneNodeTwoDataCenters) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  connect(1, 1);
+  assert_active_connections();
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * three nodes on each data center and validate the number of active connections
+ * (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest, ConnectThreeNodesTwoDataCenters) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  connect(3, 3);
+  assert_active_connections();
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * one node on nine data centers and validate the number of active connections
+ * (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest, ConnectOneNodeNineDataCenters) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Create the nine data centers
+  std::vector<unsigned int> data_center_nodes;
+  for (int i = 0; i < 9; ++i) {
+    data_center_nodes.push_back(1u);
+  }
+
+  // Ensure the control connection and normal node connection is established
+  connect(data_center_nodes);
+  assert_active_connections();
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains one
+ * node with multiple connections per host and validate the number of active
+ * connections (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest,
+  ConnectOneNodeMultipleConnectionsPerHost) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  test::driver::Cluster cluster = default_cluster()
+    .with_core_connections_per_host(CORE_CONNECTIONS_PER_HOST);
+  connect(1, 0, cluster);
+  assert_active_connections(CORE_CONNECTIONS_PER_HOST);
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * three nodes with multiple connections per host and validate the number of
+ * active connections (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest,
+  ConnectThreeNodesMultipleConnectionsPerHost) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  test::driver::Cluster cluster = default_cluster()
+    .with_core_connections_per_host(CORE_CONNECTIONS_PER_HOST);
+  connect(3, 0, cluster);
+  assert_active_connections(CORE_CONNECTIONS_PER_HOST);
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * one node on each data center and validate the number of active connections
+ * (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest,
+  ConnectOneNodeTwoDataCentersMultipleConnectionsPerHost) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  test::driver::Cluster cluster = default_cluster()
+    .with_core_connections_per_host(CORE_CONNECTIONS_PER_HOST);
+  connect(1, 1, cluster);
+  assert_active_connections(CORE_CONNECTIONS_PER_HOST);
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * three nodes on each data center and validate the number of active connections
+ * (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest,
+  ConnectThreeNodesTwoDataCentersMultipleConnectionsPerHost) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Ensure the control connection and normal node connection is established
+  test::driver::Cluster cluster = default_cluster()
+    .with_core_connections_per_host(CORE_CONNECTIONS_PER_HOST);
+  connect(3, 3, cluster);
+  assert_active_connections(CORE_CONNECTIONS_PER_HOST);
+}
+
+/**
+ * Perform connection to the SCassandra cluster
+ *
+ * This test will perform a connection to a SCassandra server that contains
+ * one node on nine data centers and validate the number of active connections
+ * (including control connection).
+ *
+ * @test_category connection
+ * @since 1.0.0
+ * @expected_result Successful connection and validation of active connections
+ */
+SCASSANDRA_INTEGRATION_TEST_F(ConnectionTest,
+  ConnectOneNodeNineDataCentersMultipleConnectionsPerHost) {
+  SKIP_TEST_IF_SCC_UNAVAILABLE;
+
+  // Create the nine data centers
+  std::vector<unsigned int> data_center_nodes;
+  for (int i = 0; i < 9; ++i) {
+    data_center_nodes.push_back(1u);
+  }
+
+  // Ensure the control connection and normal node connection is established
+  test::driver::Cluster cluster = default_cluster()
+    .with_core_connections_per_host(CORE_CONNECTIONS_PER_HOST);
+  connect(data_center_nodes, cluster);
+  assert_active_connections(CORE_CONNECTIONS_PER_HOST);
+}

--- a/tests/src/integration/tests/scassandra/test_scassandra_idempotent.cpp
+++ b/tests/src/integration/tests/scassandra/test_scassandra_idempotent.cpp
@@ -1,0 +1,182 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#include "scassandra_integration.hpp"
+#include "next_host_retry_policy.hpp"
+
+#include "cassandra.h"
+
+#include "statement.hpp"
+
+/**
+ * Idempotent integration tests
+ */
+class IdempotentTest : public SCassandraIntegration {
+public:
+  void SetUp() {
+    number_dc1_nodes_ = 3;
+    SCassandraIntegration::SetUp();
+  }
+
+  /**
+   * Create and execute a mock query with the desired idempotent setting on the
+   * statement and apply the IdempotentRetryPolicy (with logging retry policy)
+   * to advance to the next host on failures
+   *
+   * NOTE: The statement execution is performed without assertions on the
+   *       error code returned from the future; use Result::error_code() to
+   *       check value
+   *
+   * @param is_idempotent True if statement execution is idempotent; false
+   *                      otherwise (DEFAULT: true)
+   * @param apply_custom_retry_policy True if custom idempotent retry policy
+   *                                  should be enabled; false otherwise
+   *                                  (DEFAULT: true)
+   * @return Result from the executed mock query; see Result::error_code()
+   */
+  test::driver::Result execute_mock_query(bool is_idempotent = true,
+    bool apply_custom_retry_policy = true) {
+    // Create the statement with the desired idempotence and custom retry policy
+    test::driver::Statement statement("mock query");
+    statement.set_consistency(CASS_CONSISTENCY_ONE);
+    statement.set_idempotent(is_idempotent);
+    statement.set_record_attempted_hosts(true);
+
+    // Determine if the custom or default retry policy should be applied
+    test::driver::RetryPolicy policy((apply_custom_retry_policy
+      ? NextHostRetryPolicy::policy()
+      : test::driver::DefaultRetryPolicy()));
+    test::driver::LoggingRetryPolicy logging_policy(policy);
+    statement.set_retry_policy(logging_policy);
+
+    // Execute the statement and return the result
+    return session_.execute(statement, false);
+  }
+};
+
+/**
+ * Perform query using a non-idempotent statement and validate error
+ *
+ * This test will perform a query using a multi-node SCassandra server cluster
+ * simulating a write timeout on node one; each result will be validated to
+ * ensure error exists or query succeeded
+ *
+ * @test_category queries:basic
+ * @since 1.0.0
+ * @expected_result Successful result on all nodes except on node one
+ */
+SCASSANDRA_INTEGRATION_TEST_F(IdempotentTest, WriteTimeoutNonIdempotentNoRetry) {
+  // Simulate a write timeout on node 1
+  prime_mock_query_with_error(PrimingResult::WRITE_REQUEST_TIMEOUT, 1);
+
+  // Loop through all the nodes in the cluster execute the mock query
+  for (unsigned int n = 0; n < number_dc1_nodes_; ++n) {
+    test::driver::Result result = execute_mock_query(false);
+    if (result.host() == scc_->get_ip_address(1)) {
+      ASSERT_EQ(CASS_ERROR_SERVER_WRITE_TIMEOUT, result.error_code());
+    } else {
+      ASSERT_EQ(CASS_OK, result.error_code());
+    }
+  }
+}
+
+
+/**
+ * Perform query using a idempotent statement; no errors should occur
+ *
+ * This test will perform a query using a multi-node SCassandra server cluster
+ * simulating a write timeout on node one; each result will be validated to
+ * ensure query succeeded and write timeout node was attempted
+ *
+ * @test_category queries:idempotent
+ * @since 1.0.0
+ * @expected_result Successful result on all nodes
+ */
+SCASSANDRA_INTEGRATION_TEST_F(IdempotentTest, WriteTimeoutIdempotentRetry) {
+  // Simulate a write timeout on node 1 and server error on node 3
+  prime_mock_query_with_error(PrimingResult::WRITE_REQUEST_TIMEOUT, 1);
+
+  // Loop through all the nodes in the cluster execute the mock query
+  bool was_node_one_attempted = false;
+  for (unsigned int n = 0; n < number_dc1_nodes_; ++n) {
+    test::driver::Result result = execute_mock_query();
+    std::vector<std::string> attempted_hosts = result.attempted_hosts();
+    ASSERT_EQ(CASS_OK, result.error_code());
+    if (result.attempted_hosts().size() > 1) {
+      ASSERT_EQ(scc_->get_ip_address(1), attempted_hosts.at(0));
+      was_node_one_attempted = true;
+    }
+  }
+
+  // Ensure that node one was attempted (NextHostRetryPolicy used))
+  ASSERT_TRUE(was_node_one_attempted);
+}
+
+/**
+ * Perform query using a non-idempotent statement while a connection is closed
+ *
+ * This test will perform a query using a multi-node SCassandra server cluster
+ * simulating a closed connection on node one during a query; each result will
+ * be validated to ensure error exists or query succeeded
+ *
+ * @test_category queries:basic
+ * @since 1.0.0
+ * @expected_result Successful result on all nodes except on node one
+ */
+SCASSANDRA_INTEGRATION_TEST_F(IdempotentTest, ClosedConnectionNonIdempotentNoRetry) {
+  // Simulate a closed connection on node 1
+  prime_mock_query_with_error(PrimingResult::CLOSED_CONNECTION, 1);
+  std::stringstream node_closed;
+  node_closed << "to host " << scc_->get_ip_prefix() << "1 closed";
+  logger_.add_critera(node_closed.str());
+
+  // Loop through all the nodes in the cluster execute the mock query
+  for (unsigned int n = 0; n < number_dc1_nodes_; ++n) {
+    test::driver::Result result = execute_mock_query(false);
+    if (result.host() == scc_->get_ip_address(1)) {
+      ASSERT_EQ(CASS_ERROR_LIB_REQUEST_TIMED_OUT, result.error_code());
+    } else {
+      ASSERT_EQ(CASS_OK, result.error_code());
+    }
+  }
+
+  // Ensure that node one connection was closed
+  ASSERT_EQ(1, logger_.get_count());
+}
+
+
+/**
+ * Perform query using a idempotent statement while a connection is closed
+ *
+ * This test will perform a query using a multi-node SCassandra server cluster
+ * simulating a closed connection on node one during a query; each result will
+ * be validated to ensure query succeeded and closed connection node was
+ * attempted
+ *
+ * @test_category queries:idempotent
+ * @since 1.0.0
+ * @expected_result Successful result on all nodes
+ */
+SCASSANDRA_INTEGRATION_TEST_F(IdempotentTest, ClosedConnectionIdempotentRetry) {
+  // Simulate a closed connection on node 1
+  prime_mock_query_with_error(PrimingResult::CLOSED_CONNECTION, 1);
+
+  // Loop through all the nodes in the cluster execute the mock query
+  bool was_node_one_attempted = false;
+  for (unsigned int n = 0; n < number_dc1_nodes_; ++n) {
+    test::driver::Result result = execute_mock_query(true, false);
+    std::vector<std::string> attempted_hosts = result.attempted_hosts();
+    ASSERT_EQ(CASS_OK, result.error_code());
+    if (result.attempted_hosts().size() > 1) {
+      ASSERT_EQ(scc_->get_ip_address(1), attempted_hosts.at(0));
+      was_node_one_attempted = true;
+    }
+  }
+
+  // Ensure that node one was attempted (NextHostRetryPolicy used))
+  ASSERT_TRUE(was_node_one_attempted);
+}

--- a/tests/src/integration/tests/test_auth.cpp
+++ b/tests/src/integration/tests/test_auth.cpp
@@ -31,7 +31,7 @@
 /**
  * Authentication integration tests
  */
-class AuthIntegrationTest : public DseIntegration {
+class AuthenticationTest : public DseIntegration {
 public:
   static void SetUpTestCase() {
     CHECK_FOR_KERBEROS_SKIPPED_TEST;
@@ -204,8 +204,8 @@ protected:
 };
 
 // Initialize static variables
-SharedPtr<EmbeddedADS> AuthIntegrationTest::ads_;
-bool AuthIntegrationTest::is_ads_available_ = false;
+SharedPtr<EmbeddedADS> AuthenticationTest::ads_;
+bool AuthenticationTest::is_ads_available_ = false;
 
 /**
  * Perform connection to DSE using Kerberos authentication
@@ -218,7 +218,7 @@ bool AuthIntegrationTest::is_ads_available_ = false;
  * @since 1.0.0
  * @expected_result Successful connection and query execution
  */
-TEST_F(AuthIntegrationTest, KerberosAuthentication) {
+DSE_INTEGRATION_TEST_F(AuthenticationTest, KerberosAuthentication) {
   CHECK_FOR_KERBEROS_SKIPPED_TEST;
   CHECK_FAILURE;
 
@@ -239,7 +239,7 @@ TEST_F(AuthIntegrationTest, KerberosAuthentication) {
  * @since 1.0.0
  * @expected_result Connection is unsuccessful; Bad credentials
  */
-TEST_F(AuthIntegrationTest, KerberosAuthenticationFailureBadCredentials) {
+DSE_INTEGRATION_TEST_F(AuthenticationTest, KerberosAuthenticationFailureBadCredentials) {
   CHECK_FOR_KERBEROS_SKIPPED_TEST;
   CHECK_FAILURE;
 
@@ -271,7 +271,7 @@ TEST_F(AuthIntegrationTest, KerberosAuthenticationFailureBadCredentials) {
  * @since 1.0.0
  * @expected_result Connection is unsuccessful; Bad credentials
  */
-TEST_F(AuthIntegrationTest, KerberosAuthenticationFailureNoTicket) {
+DSE_INTEGRATION_TEST_F(AuthenticationTest, KerberosAuthenticationFailureNoTicket) {
   CHECK_FOR_KERBEROS_SKIPPED_TEST;
   CHECK_FAILURE;
 
@@ -300,7 +300,7 @@ TEST_F(AuthIntegrationTest, KerberosAuthenticationFailureNoTicket) {
  * @dse_version 5.0.0
  * @expected_result Successful connection and query execution
  */
-TEST_F(AuthIntegrationTest, InternalAuthentication) {
+DSE_INTEGRATION_TEST_F(AuthenticationTest, InternalAuthentication) {
   CHECK_VERSION(5.0.0);
   CHECK_FOR_KERBEROS_SKIPPED_TEST;
   CHECK_FAILURE;
@@ -323,7 +323,7 @@ TEST_F(AuthIntegrationTest, InternalAuthentication) {
  * @dse_version 5.0.0
  * @expected_result Connection is unsuccessful; Bad credentials
  */
-TEST_F(AuthIntegrationTest, InternalAuthenticationFailure) {
+DSE_INTEGRATION_TEST_F(AuthenticationTest, InternalAuthenticationFailure) {
   CHECK_VERSION(5.0.0)
   CHECK_FOR_KERBEROS_SKIPPED_TEST;
   CHECK_FAILURE;

--- a/tests/src/integration/tests/test_geometry.cpp
+++ b/tests/src/integration/tests/test_geometry.cpp
@@ -19,7 +19,7 @@
  * @dse_version 5.0.0
  */
 template<class C>
-class GeometryIntegrationTest : public DseIntegration {
+class GeometryTest : public DseIntegration {
 public:
   /**
    * Geo type values
@@ -149,7 +149,7 @@ protected:
     ASSERT_EQ(id, TimeUuid(result.first_row(), 0));
   }
 };
-TYPED_TEST_CASE_P(GeometryIntegrationTest);
+TYPED_TEST_CASE_P(GeometryTest);
 
 /**
  * Perform insert using a simple statement operation
@@ -163,13 +163,13 @@ TYPED_TEST_CASE_P(GeometryIntegrationTest);
  * @dse_version 5.0.0
  * @expected_result Geo type values are inserted and validated
  */
-TYPED_TEST_P(GeometryIntegrationTest, SimpleStatement) {
+DSE_INTEGRATION_TYPED_TEST_P(GeometryTest, SimpleStatement) {
   CHECK_VERSION(5.0.0);
 
   // Iterate over all the values in the geo type
-  for (size_t i = 0; i < GeometryIntegrationTest<TypeParam>::values_.size(); ++i) {
+  for (size_t i = 0; i < GeometryTest<TypeParam>::values_.size(); ++i) {
     // Get the value of the geo type being used
-    TypeParam value = GeometryIntegrationTest<TypeParam>::values_[i];
+    TypeParam value = GeometryTest<TypeParam>::values_[i];
 
     // Insert the geo type executed by a CQL query string statement
     TimeUuid id = this->uuid_generator_.generate_timeuuid();
@@ -224,13 +224,13 @@ TYPED_TEST_P(GeometryIntegrationTest, SimpleStatement) {
  * @dse_version 5.0.0
  * @expected_result Geo type values are inserted and validated
  */
-TYPED_TEST_P(GeometryIntegrationTest, PreparedStatement) {
+DSE_INTEGRATION_TYPED_TEST_P(GeometryTest, PreparedStatement) {
   CHECK_VERSION(5.0.0);
 
   // Iterate over all the values in the geo type
-  for (size_t i = 0; i < GeometryIntegrationTest<TypeParam>::values_.size(); ++i) {
+  for (size_t i = 0; i < GeometryTest<TypeParam>::values_.size(); ++i) {
     // Get the value of the geo type being used
-    TypeParam value = GeometryIntegrationTest<TypeParam>::values_[i];
+    TypeParam value = GeometryTest<TypeParam>::values_[i];
 
     // Bind the time UUID and geo type
     Statement statement = this->prepared_statement_.bind();
@@ -268,14 +268,14 @@ TYPED_TEST_P(GeometryIntegrationTest, PreparedStatement) {
  * @expected_result Geo type values are inserted and validated via graph
  *                  operations using a graph array (attached to a graph object)
  */
-TYPED_TEST_P(GeometryIntegrationTest, GraphArray) {
+DSE_INTEGRATION_TYPED_TEST_P(GeometryTest, GraphArray) {
   CHECK_VERSION(5.0.0);
 
   // Iterate over all the values in the geo type and add them to a graph array
   test::driver::DseGraphArray graph_array;
-  for (size_t i = 0; i < GeometryIntegrationTest<TypeParam>::values_.size(); ++i) {
+  for (size_t i = 0; i < GeometryTest<TypeParam>::values_.size(); ++i) {
     // Get the value of the geo type being used
-    TypeParam value = GeometryIntegrationTest<TypeParam>::values_[i];
+    TypeParam value = GeometryTest<TypeParam>::values_[i];
 
     // Add the value to the graph array
     graph_array.add<TypeParam>(value);
@@ -288,7 +288,7 @@ TYPED_TEST_P(GeometryIntegrationTest, GraphArray) {
   graph_statement.bind(graph_object);
 
   // Assert/Validate the geo type using a graph statement
-  this->assert_and_validate_geo_type(GeometryIntegrationTest<TypeParam>::values_,
+  this->assert_and_validate_geo_type(GeometryTest<TypeParam>::values_,
     graph_statement);
 }
 
@@ -305,13 +305,13 @@ TYPED_TEST_P(GeometryIntegrationTest, GraphArray) {
  * @expected_result Geo type values are inserted and validated via graph
  *                  operations using a graph object
  */
-TYPED_TEST_P(GeometryIntegrationTest, GraphObject) {
+DSE_INTEGRATION_TYPED_TEST_P(GeometryTest, GraphObject) {
   CHECK_VERSION(5.0.0);
 
   // Iterate over all the values in the geo type
-  for (size_t i = 0; i < GeometryIntegrationTest<TypeParam>::values_.size(); ++i) {
+  for (size_t i = 0; i < GeometryTest<TypeParam>::values_.size(); ++i) {
     // Get the value of the geo type being used
-    TypeParam value = GeometryIntegrationTest<TypeParam>::values_[i];
+    TypeParam value = GeometryTest<TypeParam>::values_[i];
 
     // Create the graph statement to insert the geo type using an object
     test::driver::DseGraphObject graph_object;
@@ -325,11 +325,13 @@ TYPED_TEST_P(GeometryIntegrationTest, GraphObject) {
 }
 
 // Register all test cases
-REGISTER_TYPED_TEST_CASE_P(GeometryIntegrationTest, SimpleStatement, PreparedStatement, GraphArray, GraphObject);
+REGISTER_TYPED_TEST_CASE_P(GeometryTest, Integration_DSE_SimpleStatement,
+  Integration_DSE_PreparedStatement, Integration_DSE_GraphArray,
+  Integration_DSE_GraphObject); //TODO: Create expanding macro for registering typed tests
 
 // Instantiate the test case for all the geo types
 typedef testing::Types<test::driver::DsePoint, test::driver::DseLineString, test::driver::DsePolygon> GeoTypes;
-INSTANTIATE_TYPED_TEST_CASE_P(Geometry, GeometryIntegrationTest, GeoTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(Geometry, GeometryTest, GeoTypes);
 
 /**
  * Perform insert and select operations for geo type point
@@ -349,7 +351,7 @@ const test::driver::DsePoint GEOMETRY_POINTS[] = {
   test::driver::DsePoint(-1.2, -100.0),
   test::driver::DsePoint() // NULL point
 };
-template<> const std::vector<test::driver::DsePoint> GeometryIntegrationTest<test::driver::DsePoint>::values_(
+template<> const std::vector<test::driver::DsePoint> GeometryTest<test::driver::DsePoint>::values_(
   GEOMETRY_POINTS,
   GEOMETRY_POINTS + sizeof(GEOMETRY_POINTS) / sizeof(GEOMETRY_POINTS[0]));
 
@@ -372,7 +374,7 @@ const test::driver::DseLineString GEOMETRY_LINE_STRING[] = {
   test::driver::DseLineString("LINESTRING EMPTY"),
   test::driver::DseLineString() // NULL line string
 };
-template<> const std::vector<test::driver::DseLineString> GeometryIntegrationTest<test::driver::DseLineString>::values_(
+template<> const std::vector<test::driver::DseLineString> GeometryTest<test::driver::DseLineString>::values_(
   GEOMETRY_LINE_STRING,
   GEOMETRY_LINE_STRING + sizeof(GEOMETRY_LINE_STRING) / sizeof(GEOMETRY_LINE_STRING[0]));
 
@@ -395,6 +397,6 @@ const test::driver::DsePolygon GEOMETRY_POLYGON[] = {
   test::driver::DsePolygon("POLYGON EMPTY"),
   test::driver::DsePolygon() // NULL polygon
 };
-template<> const std::vector<test::driver::DsePolygon> GeometryIntegrationTest<test::driver::DsePolygon>::values_(
+template<> const std::vector<test::driver::DsePolygon> GeometryTest<test::driver::DsePolygon>::values_(
   GEOMETRY_POLYGON,
   GEOMETRY_POLYGON + sizeof(GEOMETRY_POLYGON) / sizeof(GEOMETRY_POLYGON[0]));

--- a/tests/src/integration/tests/test_graph.cpp
+++ b/tests/src/integration/tests/test_graph.cpp
@@ -38,7 +38,7 @@
  *
  * @dse_version 5.0.0
  */
-class GraphIntegrationTest : public DseIntegration {
+class GraphTest : public DseIntegration {
 public:
   void SetUp() {
     CHECK_VERSION(5.0.0);
@@ -204,7 +204,7 @@ private:
  * @since 1.0.0
  * @expected_result Graph will be created and existence will be verified
  */
-TEST_F(GraphIntegrationTest, GraphExists) {
+DSE_INTEGRATION_TEST_F(GraphTest, GraphExists) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -242,7 +242,7 @@ TEST_F(GraphIntegrationTest, GraphExists) {
  * @since 1.0.0
  * @expected_result Graph will be created and existence will be verified
  */
-TEST_F(GraphIntegrationTest, ServerError) {
+DSE_INTEGRATION_TEST_F(GraphTest, ServerError) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -267,7 +267,7 @@ TEST_F(GraphIntegrationTest, ServerError) {
  * @since 1.0.0
  * @expected_result Named parameters will be assigned and validated (textual)
  */
-TEST_F(GraphIntegrationTest, MutlipleNamedParameters) {
+DSE_INTEGRATION_TEST_F(GraphTest, MutlipleNamedParameters) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -319,7 +319,7 @@ TEST_F(GraphIntegrationTest, MutlipleNamedParameters) {
  * @since 1.0.0
  * @expected_result Graph edges will be validated from classic example
  */
-TEST_F(GraphIntegrationTest, RetrieveEdges) {
+DSE_INTEGRATION_TEST_F(GraphTest, RetrieveEdges) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -362,7 +362,7 @@ TEST_F(GraphIntegrationTest, RetrieveEdges) {
  * @since 1.0.0
  * @expected_result Graph vertices will be validated from classic example
  */
-TEST_F(GraphIntegrationTest, RetrieveVertices) {
+DSE_INTEGRATION_TEST_F(GraphTest, RetrieveVertices) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -404,7 +404,7 @@ TEST_F(GraphIntegrationTest, RetrieveVertices) {
  * @since 1.0.0
  * @expected_result Graph paths will be validated from classic example
  */
-TEST_F(GraphIntegrationTest, RetrievePaths) {
+DSE_INTEGRATION_TEST_F(GraphTest, RetrievePaths) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -550,7 +550,7 @@ TEST_F(GraphIntegrationTest, RetrievePaths) {
  * @since 1.0.0
  * @expected_result Graph timestamp set will be validated
  */
-TEST_F(GraphIntegrationTest, Timestamp) {
+DSE_INTEGRATION_TEST_F(GraphTest, Timestamp) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -611,7 +611,7 @@ TEST_F(GraphIntegrationTest, Timestamp) {
  * @since 1.0.0
  * @expected_result Graph request client timeouts will be honored
  */
-TEST_F(GraphIntegrationTest, ClientRequestTimeout) {
+DSE_INTEGRATION_TEST_F(GraphTest, ClientRequestTimeout) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -653,7 +653,7 @@ TEST_F(GraphIntegrationTest, ClientRequestTimeout) {
  * @since 1.0.0
  * @expected_result Graph request server timeouts will be honored
  */
-TEST_F(GraphIntegrationTest, ServerRequestTimeout) {
+DSE_INTEGRATION_TEST_F(GraphTest, ServerRequestTimeout) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 

--- a/tests/src/integration/tests/test_graph_consistency.cpp
+++ b/tests/src/integration/tests/test_graph_consistency.cpp
@@ -19,7 +19,7 @@
  *
  * @dse_version 5.0.0
  */
-class GraphConsistencyIntegrationTest : public DseIntegration {
+class GraphConsistencyTest : public DseIntegration {
 public:
   void SetUp() {
     CHECK_VERSION(5.0.0);
@@ -183,7 +183,7 @@ private:
  * @since 1.0.0
  * @expected_result Graph read will succeed for all consistency levels applied
  */
-TEST_F(GraphConsistencyIntegrationTest, Read) {
+DSE_INTEGRATION_TEST_F(GraphConsistencyTest, Read) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -217,7 +217,7 @@ TEST_F(GraphConsistencyIntegrationTest, Read) {
  *                  and will expect failure to occur for ALL and THREE
  *                  consistency levels
  */
-TEST_F(GraphConsistencyIntegrationTest, ReadOneNodeDown) {
+DSE_INTEGRATION_TEST_F(GraphConsistencyTest, ReadOneNodeDown) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -256,7 +256,7 @@ TEST_F(GraphConsistencyIntegrationTest, ReadOneNodeDown) {
  * @since 1.0.0
  * @expected_result Graph write will succeed for all consistency levels applied
  */
-TEST_F(GraphConsistencyIntegrationTest, Write) {
+DSE_INTEGRATION_TEST_F(GraphConsistencyTest, Write) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -298,7 +298,7 @@ TEST_F(GraphConsistencyIntegrationTest, Write) {
  *                  and will expect failure to occur for ALL and THREE
  *                  consistency levels
  */
-TEST_F(GraphConsistencyIntegrationTest, WriteOneNodeDown) {
+DSE_INTEGRATION_TEST_F(GraphConsistencyTest, WriteOneNodeDown) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 

--- a/tests/src/integration/tests/test_graph_data_type.cpp
+++ b/tests/src/integration/tests/test_graph_data_type.cpp
@@ -23,7 +23,7 @@
  *
  * @dse_version 5.0.0
  */
-class GraphDataTypeIntegrationTest : public DseIntegration {
+class GraphDataTypeTest : public DseIntegration {
 public:
 
   /**
@@ -223,7 +223,7 @@ private:
  * @since 1.0.0
  * @expected_result Bigint is usable and retrievable
  */
-TEST_F(GraphDataTypeIntegrationTest, BigInteger) {
+DSE_INTEGRATION_TEST_F(GraphDataTypeTest, BigInteger) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -249,7 +249,7 @@ TEST_F(GraphDataTypeIntegrationTest, BigInteger) {
  * @since 1.0.0
  * @expected_result Decimal, double, and float are usable and retrievable
  */
-TEST_F(GraphDataTypeIntegrationTest, DecimalDoubleFloat) {
+DSE_INTEGRATION_TEST_F(GraphDataTypeTest, DecimalDoubleFloat) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -295,7 +295,7 @@ TEST_F(GraphDataTypeIntegrationTest, DecimalDoubleFloat) {
  * @since 1.0.0
  * @expected_result Int, smallint, and varint are usable and retrievable
  */
-TEST_F(GraphDataTypeIntegrationTest, IntegerSmallIntegerVarint) {
+DSE_INTEGRATION_TEST_F(GraphDataTypeTest, IntegerSmallIntegerVarint) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -335,7 +335,7 @@ TEST_F(GraphDataTypeIntegrationTest, IntegerSmallIntegerVarint) {
  * @since 1.0.0
  * @expected_result Text are usable and retrievable
  */
-TEST_F(GraphDataTypeIntegrationTest, Text) {
+DSE_INTEGRATION_TEST_F(GraphDataTypeTest, Text) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -365,7 +365,7 @@ TEST_F(GraphDataTypeIntegrationTest, Text) {
  * @since 1.0.0
  * @expected_result String results from the driver are usable and retrievable
  */
-TEST_F(GraphDataTypeIntegrationTest, StringResults) {
+DSE_INTEGRATION_TEST_F(GraphDataTypeTest, StringResults) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 

--- a/tests/src/integration/tests/test_graph_olap.cpp
+++ b/tests/src/integration/tests/test_graph_olap.cpp
@@ -29,7 +29,7 @@
  *
  * @dse_version 5.0.0
  */
-class GraphOlapIntegrationTest : public DseIntegration {
+class GraphOlapTest : public DseIntegration {
 public:
   void SetUp() {
     CHECK_VERSION(5.0.0);
@@ -166,7 +166,7 @@ private:
  * @since 1.0.0
  * @expected_result Graph analytics node will be targeted during query
  */
-TEST_F(GraphOlapIntegrationTest, AnalyticsNodeTargeted) {
+DSE_INTEGRATION_TEST_F(GraphOlapTest, AnalyticsNodeTargeted) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 
@@ -191,7 +191,7 @@ TEST_F(GraphOlapIntegrationTest, AnalyticsNodeTargeted) {
  * @since 1.0.0
  * @expected_result All graph nodes will be targeted during query
  */
-TEST_F(GraphOlapIntegrationTest, AnalyticsNodeNotTargeted) {
+DSE_INTEGRATION_TEST_F(GraphOlapTest, AnalyticsNodeNotTargeted) {
   CHECK_VERSION(5.0.0);
   CHECK_FAILURE;
 

--- a/tests/src/integration/win_debug.cpp
+++ b/tests/src/integration/win_debug.cpp
@@ -1,0 +1,114 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+#if defined(_WIN32) && defined(_DEBUG)
+# include "win_debug.hpp"
+
+# ifndef USE_VISUAL_LEAK_DETECTOR
+// Enable memory leak detection
+# define _CRTDBG_MAP_ALLOC
+# include <stdlib.h>
+# include <crtdbg.h>
+
+// Enable memory leak detection for new operator
+# ifndef DBG_NEW
+#   define DBG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
+#   define new DBG_NEW
+# endif
+
+/**
+ * Output the memory leak results to the console
+ *
+ * @param report_type Type of report (warn, error, or assert)
+ * @param message message
+ * @param error_code Error code
+ * @return Result to return to CRT processing (1 will stop processing report)
+ */
+inline int __cdecl output_memory_leak_results(int report_type, char* message, int* error_code) {
+  std::cerr << message;
+  return 1;
+}
+# endif
+
+void MemoryLeakListener::disable() {
+# ifdef USE_VISUAL_LEAK_DETECTOR
+  VLDDisable();
+# else
+  int flags = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
+  flags &= ~_CRTDBG_ALLOC_MEM_DF;
+  _CrtSetDbgFlag(flags);
+# endif
+}
+
+void MemoryLeakListener::enable() {
+# ifdef USE_VISUAL_LEAK_DETECTOR
+  VLDEnable();
+# else
+  int flags = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
+  flags |= _CRTDBG_ALLOC_MEM_DF;
+  _CrtSetDbgFlag(flags);
+# endif
+}
+
+# ifndef USE_VISUAL_LEAK_DETECTOR
+void MemoryLeakListener::OnTestProgramStart(const testing::UnitTest& unit_test) {
+  // Install the memory leak reporting
+  _CrtSetReportHook2(_CRT_RPTHOOK_INSTALL, &output_memory_leak_results);
+}
+
+void MemoryLeakListener::OnTestProgramEnd(const testing::UnitTest& unit_test) {
+  // Uninstall/Remove the memory leak reporting
+  _CrtSetReportHook2(_CRT_RPTHOOK_REMOVE, &output_memory_leak_results);
+}
+# endif
+
+void MemoryLeakListener::OnTestStart(const testing::TestInfo& test_information) {
+# ifdef USE_VISUAL_LEAK_DETECTOR
+  // Make all memory leaks (if any) as reported (clean slate)
+  VLDMarkAllLeaksAsReported();
+# else
+  // Get the starting memory state
+  _CrtMemCheckpoint(&memory_start_state_);
+# endif
+
+  // Enable memory leak detection
+  enable();
+}
+
+void MemoryLeakListener::OnTestEnd(const testing::TestInfo& test_information) {
+  // Check for memory leaks if the test was successful
+  if(test_information.result()->Passed()) {
+    check_leaks(test_information);
+  }
+}
+
+void MemoryLeakListener::check_leaks(const testing::TestInfo& test_information) {
+  // Disable memory leak checking
+  disable();
+
+# ifdef USE_VISUAL_LEAK_DETECTOR
+  // Determine if a difference exists (e.g. leak)
+  if (VLDGetLeaksCount() > 0) {
+    VLDReportLeaks();
+    VLDMarkAllLeaksAsReported();
+# else
+  // Get the ending memory state for the test
+  _CrtMemState memory_end_state;
+  _CrtMemCheckpoint(&memory_end_state);
+  _CrtMemState memory_state_difference;
+
+  // Determine if a difference exists (e.g. leak)
+  if (_CrtMemDifference(&memory_state_difference, &memory_start_state_, &memory_end_state)) {
+    _CrtMemDumpAllObjectsSince(&memory_start_state_);
+    _CrtMemDumpStatistics(&memory_state_difference);
+# endif
+    FAIL() << "Memory leaks detected in "
+      << test_information.test_case_name()
+      << "." << test_information.name();
+  }
+}
+
+#endif

--- a/tests/src/integration/win_debug.hpp
+++ b/tests/src/integration/win_debug.hpp
@@ -6,71 +6,35 @@
 */
 #ifndef __WIN_DEBUG_HPP__
 #define __WIN_DEBUG_HPP__
-#include <gtest/gtest.h>
 
 #if defined(_WIN32) && defined(_DEBUG)
 # ifdef USE_VISUAL_LEAK_DETECTOR
 #   include <vld.h>
-# else
-// Enable memory leak detection
-# define _CRTDBG_MAP_ALLOC
-# include <stdlib.h>
-# include <crtdbg.h>
-
-// Enable memory leak detection for new operator
-# ifndef DBG_NEW
-#   define DBG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
-#   define new DBG_NEW
 # endif
-
-/**
- * Output the memory leak results to the console
- *
- * @param report_type Type of report (warn, error, or assert)
- * @param message message
- * @param error_code Error code
- * @return Result to return to CRT processing (1 will stop processing report)
- */
-inline int __cdecl output_memory_leak_results(int report_type, char* message, int* error_code) {
-  std::cerr << message;
-  return 1;
-}
-# endif
+# include <gtest/gtest.h>
+#endif
 
 /**
  * Memory leak listener for detecting memory leaks on Windows more efficiently.
  */
 class MemoryLeakListener : public testing::EmptyTestEventListener {
 public:
-
+#if defined(_WIN32) && defined(_DEBUG)
 # ifndef USE_VISUAL_LEAK_DETECTOR
-  void OnTestProgramStart(const testing::UnitTest& unit_test) {
-    // Install the memory leak reporting
-    _CrtSetReportHook2(_CRT_RPTHOOK_INSTALL, &output_memory_leak_results);
-  }
-
-  void OnTestProgramEnd(const testing::UnitTest& unit_test) {
-    // Uninstall/Remove the memory leak reporting
-    _CrtSetReportHook2(_CRT_RPTHOOK_REMOVE, &output_memory_leak_results);
-  }
+  void OnTestProgramStart(const testing::UnitTest& unit_test);
+  void OnTestProgramEnd(const testing::UnitTest& unit_test);
 # endif
+  void OnTestStart(const testing::TestInfo& test_information);
+  void OnTestEnd(const testing::TestInfo& test_information);
 
-  void OnTestStart(const testing::TestInfo& test_information) {
-# ifdef USE_VISUAL_LEAK_DETECTOR
-    VLDMarkAllLeaksAsReported();
-    VLDEnable();
-# else
-    // Get the starting memory state
-    _CrtMemCheckpoint(&memory_start_state_);
-# endif
-  }
-
-  void OnTestEnd(const testing::TestInfo& test_information) {
-    // Check for memory leaks if the test was successful
-    if(test_information.result()->Passed()) {
-      check_leaks(test_information);
-    }
-}
+  /**
+   * Disable memory leak detection
+   */
+  static void disable();
+  /**
+   * Enable memory leak detection
+   */
+  static void enable();
 
 private:
 # ifndef USE_VISUAL_LEAK_DETECTOR
@@ -85,30 +49,11 @@ private:
    *
    * @param test_information Information about the test
    */
-  void check_leaks(const testing::TestInfo& test_information) {
-# ifdef USE_VISUAL_LEAK_DETECTOR
-    // Determine if a difference exists (e.g. leak)
-    VLDDisable();
-    if (VLDGetLeaksCount() > 0) {
-      VLDReportLeaks();
-      VLDMarkAllLeaksAsReported();
-# else
-    // Get the ending memory state for the test
-    _CrtMemState memory_end_state;
-    _CrtMemCheckpoint(&memory_end_state);
-    _CrtMemState memory_state_difference;
-
-    // Determine if a difference exists (e.g. leak)
-    if (_CrtMemDifference(&memory_state_difference, &memory_start_state_, &memory_end_state)) {
-      _CrtMemDumpAllObjectsSince(&memory_start_state_);
-      _CrtMemDumpStatistics(&memory_state_difference);
-# endif
-      FAIL() << "Memory leaks detected in "
-             << test_information.test_case_name()
-             << "." << test_information.name();
-    }
-  }
-};
+  void check_leaks(const testing::TestInfo& test_information);
+#else
+  static void disable() {};
+  static void enable() {};
 #endif
+};
 
 #endif // __WIN_DEBUG_HPP__

--- a/tests/src/vendor/gtest/LICENSE
+++ b/tests/src/vendor/gtest/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Initial integration of [SCassandra](http://www.scassandra.org/) into the test framework.
 - Simplified REST client using libuv
 - Allow SCassandra cluster to stay around for entire test case
 - Automatically prime SCassandra cluster (local and peers tables)
 - Allow standard 2 DCs and the ability to have N-DCs with M-nodes
 - Re-useable mock query (prime and execute; with error)
 - Enhanced memory logging (Windows)
 - SCassandra cluster reset per test in a test suite
 - Get the active connections established on SCassandra cluster

