### PR TITLE
125 - Support creating geotype objects from WKT

### DIFF
--- a/include/dse.h
+++ b/include/dse.h
@@ -1679,6 +1679,40 @@ cass_value_get_dse_point(const CassValue* value,
 
 /***********************************************************************************
  *
+ * Point
+ *
+ ***********************************************************************************/
+
+/**
+ * Parse the WKT representation of a point and extract the x,y coordinates.
+ *
+ * @public
+ *
+ * @param[in] wkt WKT representation of the point
+ * @param[out] x
+ * @param[out] y
+ * @return CASS_OK if successful, otherwise error occurred
+ */
+DSE_EXPORT CassError
+dse_wkt_as_point(const char* wkt, cass_double_t* x, cass_double_t* y);
+
+/**
+ * Parse the WKT representation (given by string and length arguments) of a point and extract
+ * the x,y coordinates.
+ *
+ * @public
+ *
+ * @param[in] wkt WKT representation of the point
+ * @param[in] wkt_length length of the wkt string
+ * @param[out] x
+ * @param[out] y
+ * @return CASS_OK if successful, otherwise error occurred
+ */
+DSE_EXPORT CassError
+dse_wkt_as_point_n(const char* wkt, size_t wkt_length, cass_double_t* x, cass_double_t* y);
+
+/***********************************************************************************
+ *
  * Line String
  *
  ***********************************************************************************/
@@ -1782,17 +1816,51 @@ DSE_EXPORT void
 dse_line_string_iterator_free(DseLineStringIterator* iterator);
 
 /**
- * Resets a line string iterator so that it can be reused.
+ * Resets a line string iterator so that it can be reused to parse WKB.
  *
  * @public @memberof DseLineStringIterator
  *
- * @param[in] iterator
- * @param[in] value
+ * @param[in] iterator the iterator to reset
+ * @param[in] value WKB representation of the line string
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError
 dse_line_string_iterator_reset(DseLineStringIterator* iterator,
                                const CassValue* value);
+
+/**
+ * Resets a line string iterator so that it can be reused to parse WKT.
+ *
+ * @public @memberof DseLineStringIterator
+ *
+ * @param[in] iterator the iterator to reset
+ * @param[in] value WKT representation of the line string
+ * @note The value string must remain allocated throughout the lifetime
+ *       of the iterator since the iterator traverses the string without
+ *       copying it.
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+DSE_EXPORT CassError
+dse_line_string_text_iterator_reset(DseLineStringIterator* iterator,
+                                    const char* value);
+
+/**
+ * Resets a line string iterator so that it can be reused to parse WKT.
+ *
+ * @public @memberof DseLineStringIterator
+ *
+ * @param[in] iterator the iterator to reset
+ * @param[in] value WKT representation (string) of the line string
+ * @param[in] value_length length of value string
+ * @note The value string must remain allocated throughout the lifetime
+ *       of the iterator since the iterator traverses the string without
+ *       copying it.
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+DSE_EXPORT CassError
+dse_line_string_text_iterator_reset_n(DseLineStringIterator* iterator,
+                                      const char* value,
+                                      size_t value_length);
 
 /**
  * Gets the number of points in the line string.
@@ -1939,17 +2007,51 @@ DSE_EXPORT void
 dse_polygon_iterator_free(DsePolygonIterator* iterator);
 
 /**
- * Resets a polygon iterator so that it can be reused.
+ * Resets a polygon iterator so that it can be reused to parse WKB.
  *
  * @public @memberof DsePolygonIterator
  *
- * @param[in] iterator
- * @param[in] value
+ * @param[in] iterator the iterator to reset
+ * @param[in] value WKB representation of the polygon
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError
 dse_polygon_iterator_reset(DsePolygonIterator* iterator,
                            const CassValue* value);
+
+/**
+ * Resets a polygon iterator so that it can be reused to parse WKT.
+ *
+ * @public @memberof DsePolygonIterator
+ *
+ * @param[in] iterator the iterator to reset
+ * @param[in] value WKT representation of the polygon
+ * @note The value string must remain allocated throughout the lifetime
+ *       of the iterator since the iterator traverses the string without
+ *       copying it.
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+DSE_EXPORT CassError
+dse_polygon_text_iterator_reset(DsePolygonIterator* iterator,
+                                const char* value);
+
+/**
+ * Resets a polygon iterator so that it can be reused to parse WKT.
+ *
+ * @public @memberof DsePolygonIterator
+ *
+ * @param[in] iterator the iterator to reset
+ * @param[in] value WKT representation (string) of the polygon
+ * @param[in] value_length length of value string
+ * @note The value string must remain allocated throughout the lifetime
+ *       of the iterator since the iterator traverses the string without
+ *       copying it.
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+DSE_EXPORT CassError
+dse_polygon_text_iterator_reset_n(DsePolygonIterator* iterator,
+                                  const char* value,
+                                  size_t value_length);
 
 /**
  * Gets the number rings in the polygon.

--- a/include/dse.h
+++ b/include/dse.h
@@ -1686,21 +1686,16 @@ cass_value_get_dse_point(const CassValue* value,
 /**
  * Parse the WKT representation of a point and extract the x,y coordinates.
  *
- * @public
- *
  * @param[in] wkt WKT representation of the point
  * @param[out] x
  * @param[out] y
  * @return CASS_OK if successful, otherwise error occurred
  */
 DSE_EXPORT CassError
-dse_wkt_as_point(const char* wkt, cass_double_t* x, cass_double_t* y);
+dse_point_from_wkt(const char* wkt, cass_double_t* x, cass_double_t* y);
 
 /**
- * Parse the WKT representation (given by string and length arguments) of a point and extract
- * the x,y coordinates.
- *
- * @public
+ * Same as dse_point_from_wkt(), but with lengths for string parameters.
  *
  * @param[in] wkt WKT representation of the point
  * @param[in] wkt_length length of the wkt string
@@ -1709,7 +1704,7 @@ dse_wkt_as_point(const char* wkt, cass_double_t* x, cass_double_t* y);
  * @return CASS_OK if successful, otherwise error occurred
  */
 DSE_EXPORT CassError
-dse_wkt_as_point_n(const char* wkt, size_t wkt_length, cass_double_t* x, cass_double_t* y);
+dse_point_from_wkt_n(const char* wkt, size_t wkt_length, cass_double_t* x, cass_double_t* y);
 
 /***********************************************************************************
  *
@@ -1816,7 +1811,8 @@ DSE_EXPORT void
 dse_line_string_iterator_free(DseLineStringIterator* iterator);
 
 /**
- * Resets a line string iterator so that it can be reused to parse WKB.
+ * Resets a line string iterator so that it can be reused to process a
+ * binary representation.
  *
  * @public @memberof DseLineStringIterator
  *
@@ -1834,33 +1830,34 @@ dse_line_string_iterator_reset(DseLineStringIterator* iterator,
  * @public @memberof DseLineStringIterator
  *
  * @param[in] iterator the iterator to reset
- * @param[in] value WKT representation of the line string
- * @note The value string must remain allocated throughout the lifetime
+ * @param[in] wkt WKT representation of the line string
+ * @note The wkt string must remain allocated throughout the lifetime
  *       of the iterator since the iterator traverses the string without
  *       copying it.
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError
-dse_line_string_text_iterator_reset(DseLineStringIterator* iterator,
-                                    const char* value);
+dse_line_string_iterator_reset_with_wkt(DseLineStringIterator* iterator,
+                                        const char* wkt);
 
 /**
- * Resets a line string iterator so that it can be reused to parse WKT.
+ * Same as dse_line_string_iterator_reset_with_wkt(), but with lengths
+ * for string parameters.
  *
  * @public @memberof DseLineStringIterator
  *
  * @param[in] iterator the iterator to reset
- * @param[in] value WKT representation (string) of the line string
- * @param[in] value_length length of value string
- * @note The value string must remain allocated throughout the lifetime
+ * @param[in] wkt WKT representation (string) of the line string
+ * @param[in] wkt_length length of wkt string
+ * @note The wkt string must remain allocated throughout the lifetime
  *       of the iterator since the iterator traverses the string without
  *       copying it.
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError
-dse_line_string_text_iterator_reset_n(DseLineStringIterator* iterator,
-                                      const char* value,
-                                      size_t value_length);
+dse_line_string_iterator_reset_with_wkt_n(DseLineStringIterator* iterator,
+                                          const char* wkt,
+                                          size_t wkt_length);
 
 /**
  * Gets the number of points in the line string.
@@ -2007,7 +2004,8 @@ DSE_EXPORT void
 dse_polygon_iterator_free(DsePolygonIterator* iterator);
 
 /**
- * Resets a polygon iterator so that it can be reused to parse WKB.
+ * Resets a polygon iterator so that it can be reused to process a
+ * binary representation.
  *
  * @public @memberof DsePolygonIterator
  *
@@ -2025,33 +2023,34 @@ dse_polygon_iterator_reset(DsePolygonIterator* iterator,
  * @public @memberof DsePolygonIterator
  *
  * @param[in] iterator the iterator to reset
- * @param[in] value WKT representation of the polygon
- * @note The value string must remain allocated throughout the lifetime
+ * @param[in] wkt WKT representation of the polygon
+ * @note The wkt string must remain allocated throughout the lifetime
  *       of the iterator since the iterator traverses the string without
  *       copying it.
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError
-dse_polygon_text_iterator_reset(DsePolygonIterator* iterator,
-                                const char* value);
+dse_polygon_iterator_reset_with_wkt(DsePolygonIterator* iterator,
+                                    const char* wkt);
 
 /**
- * Resets a polygon iterator so that it can be reused to parse WKT.
+ * Same as dse_polygon_iterator_reset_with_wkt(), but with lengths for
+ * string parameters.
  *
  * @public @memberof DsePolygonIterator
  *
  * @param[in] iterator the iterator to reset
- * @param[in] value WKT representation (string) of the polygon
- * @param[in] value_length length of value string
- * @note The value string must remain allocated throughout the lifetime
+ * @param[in] wkt WKT representation (string) of the polygon
+ * @param[in] wkt_length length of wkt string
+ * @note The wkt string must remain allocated throughout the lifetime
  *       of the iterator since the iterator traverses the string without
  *       copying it.
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError
-dse_polygon_text_iterator_reset_n(DsePolygonIterator* iterator,
-                                  const char* value,
-                                  size_t value_length);
+dse_polygon_iterator_reset_with_wkt_n(DsePolygonIterator* iterator,
+                                      const char* wkt,
+                                      size_t wkt_length);
 
 /**
  * Gets the number rings in the polygon.

--- a/include/dse.h
+++ b/include/dse.h
@@ -1817,7 +1817,7 @@ dse_line_string_iterator_free(DseLineStringIterator* iterator);
  * @public @memberof DseLineStringIterator
  *
  * @param[in] iterator the iterator to reset
- * @param[in] value WKB representation of the line string
+ * @param[in] value binary representation of the line string
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError
@@ -2010,7 +2010,7 @@ dse_polygon_iterator_free(DsePolygonIterator* iterator);
  * @public @memberof DsePolygonIterator
  *
  * @param[in] iterator the iterator to reset
- * @param[in] value WKB representation of the polygon
+ * @param[in] value binary representation of the polygon
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 DSE_EXPORT CassError

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -769,7 +769,7 @@ CassError dse_graph_result_as_point(const DseGraphResult* result,
     return CASS_ERROR_LIB_BAD_PARAMS;
   }
 
-  return dse_wkt_as_point_n(result->GetString(), result->GetStringLength(), x, y);
+  return dse_point_from_wkt_n(result->GetString(), result->GetStringLength(), x, y);
 }
 
 CassError dse_graph_result_as_line_string(const DseGraphResult* result,

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -769,27 +769,7 @@ CassError dse_graph_result_as_point(const DseGraphResult* result,
     return CASS_ERROR_LIB_BAD_PARAMS;
   }
 
-  WktLexer lexer(result->GetString(), result->GetStringLength());
-
-  if (lexer.next_token() != WktLexer::TK_TYPE_POINT ||
-      lexer.next_token() != WktLexer::TK_OPEN_PAREN ||
-      lexer.next_token() != WktLexer::TK_NUMBER) {
-    return CASS_ERROR_LIB_BAD_PARAMS;
-  }
-
-  *x = lexer.number();
-
-  if (lexer.next_token() != WktLexer::TK_NUMBER) {
-    return CASS_ERROR_LIB_BAD_PARAMS;
-  }
-
-  *y = lexer.number();
-
-  if (lexer.next_token() != WktLexer::TK_CLOSE_PAREN) {
-    return CASS_ERROR_LIB_BAD_PARAMS;
-  }
-
-  return CASS_OK;
+  return dse_wkt_as_point_n(result->GetString(), result->GetStringLength(), x, y);
 }
 
 CassError dse_graph_result_as_line_string(const DseGraphResult* result,

--- a/src/line_string.cpp
+++ b/src/line_string.cpp
@@ -55,6 +55,17 @@ CassError dse_line_string_iterator_reset(DseLineStringIterator *iterator, const 
   return iterator->reset_binary(value);
 }
 
+CassError dse_line_string_text_iterator_reset_n(DseLineStringIterator* iterator,
+                                                const char* value,
+                                                size_t value_length) {
+  return iterator->reset_text(value, value_length);
+}
+
+CassError dse_line_string_text_iterator_reset(DseLineStringIterator* iterator,
+                                              const char* value) {
+  return dse_line_string_text_iterator_reset_n(iterator, value, strlen(value));
+}
+
 cass_uint32_t dse_line_string_iterator_num_points(const DseLineStringIterator* iterator) {
   return iterator->num_points();
 }

--- a/src/line_string.cpp
+++ b/src/line_string.cpp
@@ -55,15 +55,15 @@ CassError dse_line_string_iterator_reset(DseLineStringIterator *iterator, const 
   return iterator->reset_binary(value);
 }
 
-CassError dse_line_string_text_iterator_reset_n(DseLineStringIterator* iterator,
-                                                const char* value,
-                                                size_t value_length) {
-  return iterator->reset_text(value, value_length);
+CassError dse_line_string_iterator_reset_with_wkt_n(DseLineStringIterator* iterator,
+                                                    const char* wkt,
+                                                    size_t wkt_length) {
+  return iterator->reset_text(wkt, wkt_length);
 }
 
-CassError dse_line_string_text_iterator_reset(DseLineStringIterator* iterator,
-                                              const char* value) {
-  return dse_line_string_text_iterator_reset_n(iterator, value, strlen(value));
+CassError dse_line_string_iterator_reset_with_wkt(DseLineStringIterator* iterator,
+                                                  const char* wkt) {
+  return dse_line_string_iterator_reset_with_wkt_n(iterator, wkt, strlen(wkt));
 }
 
 cass_uint32_t dse_line_string_iterator_num_points(const DseLineStringIterator* iterator) {

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -12,11 +12,11 @@
 
 extern "C" {
 
-CassError dse_wkt_as_point(const char* wkt, cass_double_t* x, cass_double_t* y) {
-  return dse_wkt_as_point_n(wkt, strlen(wkt), x, y);
+CassError dse_point_from_wkt(const char* wkt, cass_double_t* x, cass_double_t* y) {
+  return dse_point_from_wkt_n(wkt, strlen(wkt), x, y);
 }
 
-CassError dse_wkt_as_point_n(const char* wkt, size_t wkt_length, cass_double_t* x, cass_double_t* y) {
+CassError dse_point_from_wkt_n(const char* wkt, size_t wkt_length, cass_double_t* x, cass_double_t* y) {
   WktLexer lexer(wkt, wkt_length);
 
   if (lexer.next_token() != WktLexer::TK_TYPE_POINT ||

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -1,0 +1,43 @@
+/*
+  Copyright (c) 2016 DataStax, Inc.
+
+  This software can be used solely with DataStax Enterprise. Please consult the
+  license at http://www.datastax.com/terms/datastax-dse-driver-license-terms
+*/
+
+#include "dse.h"
+#include "wkt.hpp"
+
+#include <string.h>
+
+extern "C" {
+
+CassError dse_wkt_as_point(const char* wkt, cass_double_t* x, cass_double_t* y) {
+  return dse_wkt_as_point_n(wkt, strlen(wkt), x, y);
+}
+
+CassError dse_wkt_as_point_n(const char* wkt, size_t wkt_length, cass_double_t* x, cass_double_t* y) {
+  WktLexer lexer(wkt, wkt_length);
+
+  if (lexer.next_token() != WktLexer::TK_TYPE_POINT ||
+      lexer.next_token() != WktLexer::TK_OPEN_PAREN ||
+      lexer.next_token() != WktLexer::TK_NUMBER) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+
+  *x = lexer.number();
+
+  if (lexer.next_token() != WktLexer::TK_NUMBER) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+
+  *y = lexer.number();
+
+  if (lexer.next_token() != WktLexer::TK_CLOSE_PAREN) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+
+  return CASS_OK;
+}
+
+} // extern "C"

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -55,6 +55,17 @@ CassError dse_polygon_iterator_reset(DsePolygonIterator* iterator,
   return iterator->reset_binary(value);
 }
 
+CassError dse_polygon_text_iterator_reset_n(DsePolygonIterator* iterator,
+                                            const char* value,
+                                            size_t value_length) {
+  return iterator->reset_text(value, value_length);
+}
+
+CassError dse_polygon_text_iterator_reset(DsePolygonIterator* iterator,
+                                          const char* value) {
+  return dse_polygon_text_iterator_reset_n(iterator, value, strlen(value));
+}
+
 void dse_polygon_iterator_free(DsePolygonIterator* iterator) {
   delete iterator->from();
 }

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -55,15 +55,15 @@ CassError dse_polygon_iterator_reset(DsePolygonIterator* iterator,
   return iterator->reset_binary(value);
 }
 
-CassError dse_polygon_text_iterator_reset_n(DsePolygonIterator* iterator,
-                                            const char* value,
-                                            size_t value_length) {
-  return iterator->reset_text(value, value_length);
+CassError dse_polygon_iterator_reset_with_wkt_n(DsePolygonIterator* iterator,
+                                                const char* wkt,
+                                                size_t wkt_length) {
+  return iterator->reset_text(wkt, wkt_length);
 }
 
-CassError dse_polygon_text_iterator_reset(DsePolygonIterator* iterator,
-                                          const char* value) {
-  return dse_polygon_text_iterator_reset_n(iterator, value, strlen(value));
+CassError dse_polygon_iterator_reset_with_wkt(DsePolygonIterator* iterator,
+                                              const char* wkt) {
+  return dse_polygon_iterator_reset_with_wkt_n(iterator, wkt, strlen(wkt));
 }
 
 void dse_polygon_iterator_free(DsePolygonIterator* iterator) {


### PR DESCRIPTION
* Added C functions to expose wkt parsing iterators for line string and polygon.

* Added C functions to parse point wkt to retrieve x,y (factored out of some graph response parsing code).